### PR TITLE
Fix for transactions not showing on systems where 12-hour clock is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /.build
 /Packages
+/.swiftpm

--- a/Sources/EmealKit/Cardservice/Cardservice.swift
+++ b/Sources/EmealKit/Cardservice/Cardservice.swift
@@ -21,7 +21,7 @@ public struct Cardservice {
     ///   - session: URLSession, defaults to .shared
     ///   - completion: handler
     public static func login(username: String, password: String, session: URLSession = .shared, completion: @escaping (Result<Cardservice, CardserviceError>) -> Void) {
-        let url = URL(string: "?karteNr=\(username)&format=JSON&datenformat=JSON", relativeTo: URL.Cardervice.login)!
+        let url = URL(string: "?karteNr=\(username)&format=JSON&datenformat=JSON", relativeTo: URL.Cardservice.login)!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -54,7 +54,7 @@ public struct Cardservice {
     ///   - session: URLSession, defaults to .shared
     ///   - completion: handler
     public func carddata(session: URLSession = .shared, completion: @escaping (Result<[CardData], CardserviceError>) -> Void) {
-        let url = URL(string: "?format=JSON&authToken=\(self.authToken)&karteNr=\(self.cardnumber)", relativeTo: URL.Cardervice.carddata)!
+        let url = URL(string: "?format=JSON&authToken=\(self.authToken)&karteNr=\(self.cardnumber)", relativeTo: URL.Cardservice.carddata)!
         let request = URLRequest(url: url)
         session.cardserviceDataTask(with: request, session: session) { (result: Result<[CardDataService], CardserviceError>) in
             switch result {
@@ -80,11 +80,11 @@ public struct Cardservice {
 
         let transactionURL = URL(
             string: "?format=JSON&authToken=\(self.authToken)&karteNr=\(self.cardnumber)&datumVon=\(begin.shortGerman)&datumBis=\(end.shortGerman)",
-            relativeTo: URL.Cardervice.transactions)!
+            relativeTo: URL.Cardservice.transactions)!
         let transactionRequest = URLRequest(url: transactionURL)
         let positionsURL = URL(
             string: "?format=JSON&authToken=\(self.authToken)&karteNr=\(self.cardnumber)&datumVon=\(begin.shortGerman)&datumBis=\(end.shortGerman)",
-            relativeTo: URL.Cardervice.transactionPositions)!
+            relativeTo: URL.Cardservice.transactionPositions)!
         let positionsRequest = URLRequest(url: positionsURL)
 
         session.cardserviceDataTask(with: transactionRequest, session: session) { (transactionsResult: Result<[TransactionService], CardserviceError>) in

--- a/Sources/EmealKit/Cardservice/CardserviceAPI.swift
+++ b/Sources/EmealKit/Cardservice/CardserviceAPI.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 internal extension URL {
-    enum Cardervice {
+    enum Cardservice {
         static let baseUrl = URL(string: "https://kartenservicedaten.studentenwerk-dresden.de:8080/")!
         static let apiBase = URL(string: "TL1/TLM/KASVC/", relativeTo: Self.baseUrl)!
         static let login = URL(string: "LOGIN", relativeTo: Self.apiBase)!

--- a/Sources/EmealKit/Date+short.swift
+++ b/Sources/EmealKit/Date+short.swift
@@ -17,6 +17,7 @@ extension Date {
 
     static var shortGermanDateTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "dd.MM.yyyy HH:mm"
         return formatter
     }()


### PR DESCRIPTION
### About
So this turned out to be a rather weird though simple one - apparently on systems where the 24-hour clock is disabled, this setting will override the "HH" part of the standard time pattern. As the docs state: 

> In all cases, you should consider that formatters default to using the user’s locale (currentLocale) superimposed with the user’s preference settings. 
[Ref.](https://developer.apple.com/library/archive/qa/qa1480/_index.html#//apple_ref/doc/uid/DTS40009878)

By setting the locale to `en_US_POSIX`, we ensure we're using a fixed locale:

> [...] if you're working with fixed-format dates, you should first set the locale of the date formatter to something appropriate for your fixed format. In most cases the best locale to choose is "en_US_POSIX", a locale that's specifically designed to yield US English results regardless of both user and system preferences. "en_US_POSIX" is also invariant in time (if the US, at some point in the future, changes the way it formats dates, "en_US" will change to reflect the new behaviour, but "en_US_POSIX" will not), and between machines ("en_US_POSIX" works the same on iOS as it does on OS X, and as it it does on other platforms).
[Ref.](https://developer.apple.com/library/archive/qa/qa1480/_index.html#//apple_ref/doc/uid/DTS40009878)


### Other minor changes
- Fixed a typo, "Cardervice" struct to "Cardservice"
- Added .swiftpm directory to gitignore

### Notes for maintainers
Yeah, not sure how small you want your commits to be, not a lot that has changed but I'm used to making commits per "feature", feel free to squash them if they're too small haha.


<s>Fi<a></a>xes https://github.com/kiliankoe/MensaDresden/issues/64</s>