### PR TITLE
Add async/await support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,5 +26,8 @@ let package = Package(
         .testTarget(
             name: "EmealKitTests",
             dependencies: ["EmealKit"]),
+        .testTarget(
+            name: "APIValidationTests",
+            dependencies: ["EmealKit"]),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -6,48 +6,34 @@ Swift library for accessing some of the meal related data the [Studentenwerk Dre
 
 ## Quick Start
 
-### Current Meal or Canteen Information
+### Current meals or available canteens
 
 ```swift
-Meal.for(canteen: .alteMensa, on: Date()) { result in
-    guard let meals = result.success else { return }
-    
-    for meal in meals {
-        print(meal.name)
-    }
+let meals = try await Meal.for(canteen: .alteMensa, on: Date())
+for meal in meals {
+    print(meal.name)
 }
 
-Canteen.all { result in
-    guard let canteens = result.success else { return }
-    
-    for canteen in canteens {
-        print(canteen.name)
-    }
+let canteens = try await Canteen.all()
+for canteen in canteens {
+    print(canteen.name)
 }
 ```
 
-Both of these requests also offer publishers for use with Combine.
+A completion block based API and one built on Combine are also available. 
 
 ### Cardservice
 
 Talk to the [Cardservice](www.studentenwerk-dresden.de/mensen/kartenservice/) to acquire data about your Emeal card. You will need to have registered for Autoload to have the necessary authentication details.
 
 ```swift
-Cardservice.login(username: "1234567890", password: "hunter2") { result in
-    guard let service = result.success else { return }
-    
-    service.carddata { result in
-        guard let data = result.success else { return }
-        print(data)
-    }
-    
-    let twoDaysAgo = Date().addingTimeInterval(-60 * 60 * 24 * 2)
-    let now = Date()
-    service.transactions(begin: twoDaysAgo, end: now) { result in
-        guard let transactions = result.success else { return }
-        print(transactions)
-    }
-}
+let cardservice = try await Cardservice.login(username: "1234567890", password: "hunter2")
+let carddata = try await cardservice.carddata()
+print(carddata)
+
+let twoDaysAgo = Date().addingTimeInterval(-60 * 60 * 24 * 2)
+let transactions = try await cardservice.transactions(begin: twoDaysAgo)
+print(transactions)
 ```
 
 ### NFC Scanning

--- a/Sources/EmealKit/Mensa/MensaAPI.swift
+++ b/Sources/EmealKit/Mensa/MensaAPI.swift
@@ -52,6 +52,15 @@ extension Canteen {
             }
         }
     }
+
+    @available(macOS 12.0, iOS 15.0, *)
+    public static func all(session: URLSession = .shared) async throws -> [Canteen] {
+        try await withCheckedThrowingContinuation { continuation in
+            Self.all(session: session) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
 }
 
 #if canImport(Combine)
@@ -92,6 +101,20 @@ extension Meal {
                 } catch let error {
                     completion(.failure(.other(error)))
                 }
+            }
+        }
+    }
+
+    @available(macOS 12.0, iOS 15.0, *)
+    public static func `for`(canteen: CanteenId, on date: Date, session: URLSession = .shared) async throws -> [Meal] {
+        try await Self.for(canteen: canteen.rawValue, on: date, session: session)
+    }
+
+    @available(macOS 12.0, iOS 15.0, *)
+    public static func `for`(canteen: Int, on date: Date, session: URLSession = .shared) async throws -> [Meal] {
+        try await withCheckedThrowingContinuation { continuation in
+            Self.for(canteen: canteen, on: date, session: session) { result in
+                continuation.resume(with: result)
             }
         }
     }

--- a/Tests/APIValidationTests/CardserviceAPITests.swift
+++ b/Tests/APIValidationTests/CardserviceAPITests.swift
@@ -7,11 +7,14 @@ class CardserviceAPITests: XCTestCase {
     lazy var username: String = ProcessInfo.processInfo.environment["EMEAL_USERNAME"]!
     lazy var password: String = ProcessInfo.processInfo.environment["EMEAL_PASSWORD"]!
 
-    // The API is quick to throw 429 status codes on too many consecutive requests, that's why we're sleeping half a
-    // second between them.
+    override func setUp() {
+        // The API is quick to throw 429 status codes on too many consecutive requests, that's why we're sleeping a
+        // second between them.
+        Thread.sleep(forTimeInterval: 1)
+        super.setUp()
+    }
 
     func testLoginFailure() async {
-        Thread.sleep(forTimeInterval: 0.5)
         do {
             _ = try await Cardservice.login(username: "", password: "")
             XCTFail("Shouldn't succeed with no login details")
@@ -24,19 +27,16 @@ class CardserviceAPITests: XCTestCase {
     }
 
     func testLoginSuccess() async throws {
-        Thread.sleep(forTimeInterval: 0.5)
         _ = try await Cardservice.login(username: username, password: password)
     }
 
     func testFetchCarddata() async throws {
-        Thread.sleep(forTimeInterval: 0.5)
         let cardservice = try await Cardservice.login(username: username, password: password)
         let carddata = try await cardservice.carddata()
         XCTAssert(!carddata.isEmpty)
     }
 
     func testFetchTransactions() async throws {
-        Thread.sleep(forTimeInterval: 0.5)
         let cardservice = try await Cardservice.login(username: username, password: password)
         let oneWeekAgo = Date().addingTimeInterval(-1 * 60 * 60 * 24 * 7)
         _ = try await cardservice.transactions(begin: oneWeekAgo)

--- a/Tests/APIValidationTests/CardserviceAPITests.swift
+++ b/Tests/APIValidationTests/CardserviceAPITests.swift
@@ -3,7 +3,7 @@ import XCTest
 import EmealKit
 
 @available(macOS 12.0, iOS 15.0, *)
-class CardserviceTests: XCTestCase {
+class CardserviceAPITests: XCTestCase {
     lazy var username: String = ProcessInfo.processInfo.environment["EMEAL_USERNAME"]!
     lazy var password: String = ProcessInfo.processInfo.environment["EMEAL_PASSWORD"]!
 

--- a/Tests/APIValidationTests/MenuAPITests.swift
+++ b/Tests/APIValidationTests/MenuAPITests.swift
@@ -2,7 +2,7 @@ import XCTest
 import EmealKit
 
 @available(macOS 12.0, iOS 15.0, *)
-class APITests: XCTestCase {
+class MenuAPITests: XCTestCase {
     static let expectedCanteenCount = 21
 
     /// Tests expect one of the following canteens to have meals for the current day, otherwise they fail.

--- a/Tests/EmealKitTests/APITests.swift
+++ b/Tests/EmealKitTests/APITests.swift
@@ -1,73 +1,37 @@
 import XCTest
 import EmealKit
 
+@available(macOS 12.0, iOS 15.0, *)
 class APITests: XCTestCase {
     static let expectedCanteenCount = 21
 
     /// Tests expect one of the following canteens to have meals for the current day, otherwise they fail.
     static let expectedOpenCanteens: [CanteenId] = [.alteMensa, .mensaSiedepunkt, .mensaReichenbachstraße]
 
-    func testCanteenData() {
-        let e = expectation(description: "get current canteen data")
+    func testCanteenData() async throws {
+        let canteens = try await Canteen.all()
+        XCTAssert(!canteens.isEmpty, "No canteens found in response.")
+        XCTAssertEqual(canteens.count, Self.expectedCanteenCount)
 
-        Canteen.all { result in
-            defer { e.fulfill() }
-
-            guard let canteens = try? result.get() else {
-                XCTFail("Invalid response.")
-                return
-            }
-
-            if canteens.isEmpty {
-                XCTFail("No canteens found in response.")
-            }
-
-            let canteensList = canteens
-                .sorted { $0.id < $1.id }
-                .map { "\($0.id) \($0.name)" }
-                .joined(separator: "\n- ")
-            print("Found the following \(canteens.count) canteens: \n- \(canteensList)")
-
-            XCTAssertEqual(canteens.count, Self.expectedCanteenCount)
-        }
-
-        waitForExpectations(timeout: 10)
+        let canteenList = canteens
+            .sorted { $0.id < $1.id }
+            .map { "\($0.id) \($0.name)" }
+            .joined(separator: "\n- ")
+        print("Found the following \(canteens.count) canteens: \n- \(canteenList)")
     }
 
-    func testMealData() {
-        let e = expectation(description: "get current meal data")
-
+    func testMealData() async throws {
         let date = Date()
-
         var foundMeals = false
 
-        for canteen in Self.expectedOpenCanteens {
-            let semaphore = DispatchSemaphore(value: 0)
-
-            Meal.for(canteen: canteen, on: date) { result in
-                defer { semaphore.signal() }
-
-                guard let meals = try? result.get() else {
-                    XCTFail("Invalid response: \(result)")
-                    return
-                }
-
-                if !meals.isEmpty {
-                    foundMeals = true
-                    print("Found \(meals.count) meals at \(canteen) on \(date).")
-                }
-            }
-
-            semaphore.wait()
-
-            if foundMeals {
+        for canteenId in Self.expectedOpenCanteens {
+            let meals = try await Meal.for(canteen: canteenId, on: date)
+            if !meals.isEmpty {
+                foundMeals = true
                 break
             }
         }
 
         XCTAssert(foundMeals, "No meals found at these canteens: \(Self.expectedOpenCanteens)")
-        e.fulfill()
-
-        waitForExpectations(timeout: 20)
     }
 }

--- a/Tests/EmealKitTests/CanteenTests.swift
+++ b/Tests/EmealKitTests/CanteenTests.swift
@@ -3,15 +3,10 @@ import EmealKit
 import CoreLocation
 
 class CanteenTests: XCTestCase {
-    func testFetch() {
-        let e = expectation(description: "fetch canteen data")
-
-        Canteen.all(session: MockURLSession(mockData: .canteens)) { result in
-            defer { e.fulfill() }
-            XCTAssertNotNil(try? result.get(), "Expected canteen data")
-        }
-
-        waitForExpectations(timeout: 1)
+    @available(macOS 12.0, iOS 15.0, *)
+    func testMockFetchAndDecode() async throws {
+        let canteens = try await Canteen.all(session: MockURLSession(mockData: .canteens))
+        XCTAssertEqual(canteens.count, 21)
     }
 
     func testLocation() {

--- a/Tests/EmealKitTests/CardserviceTests.swift
+++ b/Tests/EmealKitTests/CardserviceTests.swift
@@ -23,35 +23,23 @@ class CardserviceTests: XCTestCase {
         }
     }
 
-    func testLoginSuccess() async {
+    func testLoginSuccess() async throws {
         Thread.sleep(forTimeInterval: 0.5)
-        do {
-            _ = try await Cardservice.login(username: username, password: password)
-        } catch {
-            XCTFail("Login should not fail. \(error)")
-        }
+        _ = try await Cardservice.login(username: username, password: password)
     }
 
-    func testFetchCarddata() async {
+    func testFetchCarddata() async throws {
         Thread.sleep(forTimeInterval: 0.5)
-        do {
-            let cardservice = try await Cardservice.login(username: username, password: password)
-            let carddata = try await cardservice.carddata()
-            XCTAssert(!carddata.isEmpty)
-        } catch {
-            XCTFail("Fetching carddata should not fail. \(error)")
-        }
+        let cardservice = try await Cardservice.login(username: username, password: password)
+        let carddata = try await cardservice.carddata()
+        XCTAssert(!carddata.isEmpty)
     }
 
-    func testFetchTransactions() async {
+    func testFetchTransactions() async throws {
         Thread.sleep(forTimeInterval: 0.5)
-        do {
-            let cardservice = try await Cardservice.login(username: username, password: password)
-            let oneWeekAgo = Date().addingTimeInterval(-1 * 60 * 60 * 24 * 7)
-            _ = try await cardservice.transactions(begin: oneWeekAgo)
-            // Can't really assert anything here, the list of transactions is likely empty, but at least it didn't fail.
-        } catch {
-            XCTFail("Fetching transactions should not fail. \(error)")
-        }
+        let cardservice = try await Cardservice.login(username: username, password: password)
+        let oneWeekAgo = Date().addingTimeInterval(-1 * 60 * 60 * 24 * 7)
+        _ = try await cardservice.transactions(begin: oneWeekAgo)
+        // Can't really assert anything here, the list of transactions is likely empty, but at least it didn't fail.
     }
 }

--- a/Tests/EmealKitTests/MealTests.swift
+++ b/Tests/EmealKitTests/MealTests.swift
@@ -2,14 +2,10 @@ import XCTest
 import EmealKit
 
 class MealTests: XCTestCase {
-    func testFetch() {
-        let e = expectation(description: "fetch meal data")
-        Meal.for(canteen: .alteMensa, on: Date(), session: MockURLSession(mockData: .meals)) { result in
-            defer { e.fulfill() }
-            XCTAssertNotNil(try? result.get(), "Expected meal data")
-        }
-
-        waitForExpectations(timeout: 1)
+    @available(macOS 12.0, iOS 15.0, *)
+    func testMockFetchAndDecode() async throws {
+        let meals = try await Meal.for(canteen: .alteMensa, on: Date(), session: MockURLSession(mockData: .meals))
+        XCTAssertEqual(meals.count, 5)
     }
 
     func testPlaceholderImage() {


### PR DESCRIPTION
This'll have to stay unmerged until GitHub CI can handle a version of macOS that runs async/await stuff. I don't want to disable the APITests cron action.