### PR TITLE
Opening hours scraping support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,12 +11,39 @@
         }
       },
       {
+        "package": "LRUCache",
+        "repositoryURL": "https://github.com/nicklockwood/LRUCache.git",
+        "state": {
+          "branch": null,
+          "revision": "cb5b2bd0da83ad29c0bec762d39f41c8ad0eaf3e",
+          "version": "1.2.1"
+        }
+      },
+      {
         "package": "Regex",
         "repositoryURL": "https://github.com/sharplet/Regex.git",
         "state": {
           "branch": null,
           "revision": "76c2b73d4281d77fc3118391877efd1bf972f515",
           "version": "2.1.1"
+        }
+      },
+      {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "b601256eab081c0f92f059e12818ac1d4f178ff7",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "SwiftSoup",
+        "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
+        "state": {
+          "branch": null,
+          "revision": "d86f244ed497d48012782e2f59c985a55e77b3f5",
+          "version": "2.11.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,11 +18,12 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/alexaubry/HTMLString.git", from: "5.0.0"),
         .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.0"),
+        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.11.2"),
     ],
     targets: [
         .target(
             name: "EmealKit",
-            dependencies: ["HTMLString", "Regex"]),
+            dependencies: ["HTMLString", "Regex", "SwiftSoup"]),
         .testTarget(
             name: "EmealKitTests",
             dependencies: ["EmealKit"]),

--- a/Sources/EmealKit/Cardservice/Transaction.swift
+++ b/Sources/EmealKit/Cardservice/Transaction.swift
@@ -93,7 +93,7 @@ extension Transaction {
         public let discount: Double?
         public let rating: Int // ?
 
-        public init(clientID: Int, id: Int, transactionID: String, positionID: Int, name: String, amount: Int, price: Double, totalPrice: Double, discount: Double, rating: Int) {
+        public init(clientID: Int, id: Int, transactionID: String, positionID: Int, name: String, amount: Int, price: Double, totalPrice: Double, discount: Double? = nil, rating: Int) {
             self.clientID = clientID
             self.id = id
             self.transactionID = transactionID

--- a/Sources/EmealKit/Cardservice/Transaction.swift
+++ b/Sources/EmealKit/Cardservice/Transaction.swift
@@ -90,9 +90,10 @@ extension Transaction {
         public let amount: Int
         public let price: Double
         public let totalPrice: Double
+        public let discount: Double?
         public let rating: Int // ?
 
-        public init(clientID: Int, id: Int, transactionID: String, positionID: Int, name: String, amount: Int, price: Double, totalPrice: Double, rating: Int) {
+        public init(clientID: Int, id: Int, transactionID: String, positionID: Int, name: String, amount: Int, price: Double, totalPrice: Double, discount: Double, rating: Int) {
             self.clientID = clientID
             self.id = id
             self.transactionID = transactionID
@@ -101,6 +102,7 @@ extension Transaction {
             self.amount = amount
             self.price = price
             self.totalPrice = totalPrice
+            self.discount = discount
             self.rating = rating
         }
 
@@ -113,6 +115,7 @@ extension Transaction {
             case amount = "menge"
             case price = "epreis"
             case totalPrice = "gpreis"
+            case discount = "rabatt"
             case rating = "bewertung"
         }
     }

--- a/Sources/EmealKit/Mensa/Canteen.swift
+++ b/Sources/EmealKit/Mensa/Canteen.swift
@@ -12,6 +12,7 @@ public struct Canteen: Identifiable, Equatable, Decodable {
     public var coordinates: [Double]
     public var url: URL
     public var menu: URL
+    public var openingHours: OpeningHours?
 
     #if canImport(CoreLocation)
     public var location: CLLocation? {
@@ -21,7 +22,7 @@ public struct Canteen: Identifiable, Equatable, Decodable {
     }
     #endif
 
-    public init(id: Int, name: String, city: String, address: String, coordinates: [Double], url: URL, menu: URL) {
+    public init(id: Int, name: String, city: String, address: String, coordinates: [Double], url: URL, menu: URL, openingHours: OpeningHours? = nil) {
         self.id = id
         self.name = name
         self.city = city
@@ -29,6 +30,24 @@ public struct Canteen: Identifiable, Equatable, Decodable {
         self.coordinates = coordinates
         self.url = url
         self.menu = menu
+        self.openingHours = openingHours
+    }
+    
+    // MARK: - Opening Hours Convenience Methods
+    
+    /// Check if the canteen is currently open
+    public func isOpen(at date: Date = Date()) -> Bool {
+        openingHours?.isOpen(at: date) ?? false
+    }
+    
+    /// Get the time when the canteen closes (if currently open)
+    public func closingTime(from date: Date = Date()) -> (Date?, String?)? {
+        openingHours?.closingTime(from: date)
+    }
+    
+    /// Get the time when the canteen opens next (if currently closed)
+    public func openingTime(from date: Date = Date()) -> (Date?, String?)? {
+        openingHours?.openingTime(from: date)
     }
 }
 
@@ -65,30 +84,36 @@ public enum CanteenId: Int, CaseIterable {
         switch name {
         case "alte", "mommsa", "brat2", "bratquadrat":
             return .alteMensa
-        case "uboot", "bio":
+        case "uboot", "bio", "u-boot":
             return .bioMensaUBoot
         case "brühl", "bruehl", "hfbk":
             return .mensaBrühl
-        case "görlitz", "goerlitz":
+        case "görlitz", "goerlitz", "mio - mensa im osten", "im osten", "mio -  im osten", "mio":
             return .mensaGörlitz
-        case "jotown", "ba", "alte fakultät":
+        case "jotown", "ba", "alte fakultät", "johanna", "johannstadt":
             return .mensaJohannstadt
-        case "palucca", "tanz":
+        case "palucca", "tanz", "palucca hochschule":
             return .mensaPaluccaHochschule
-        case "reichenbach", "htw", "reiche", "club":
+        case "reichenbach", "htw", "reiche", "club", "matrix":
             return .mensaReichenbachstraße
         case "siede", "siedepunkt", "drepunct", "drehpunkt", "siedepunct", "slub":
             return .mensaSiedepunkt
-        case "stimmgabel", "hfm", "musik", "musikhochschule":
+        case "stimmgabel", "stimm-gabel", "hfm", "musik", "musikhochschule":
             return .mensaStimmGabel
-        case "tharandt", "tellerrand":
+        case "tharandt", "tellerrand", "tellerrandt":
             return .mensaTellerRandt
-        case "wu", "wu1", "wundtstraße":
+        case "wu", "wu1", "wundtstraße", "wueins":
             return .mensaWUeinsSportsbar
-        case "zelt", "schlösschen", "feldschlösschen":
+        case "zelt", "schlösschen", "feldschlösschen", "zeltschlösschen":
             return .zeltschlösschen
         case "grill", "cube", "fresswürfel", "würfel", "wuerfel", "burger", "grillcube":
             return .grillCube
+        case "mensologie":
+            return .mensologie
+        case "mahlwerk":
+            return .mensaMahlwerk
+        case "kraatschn":
+            return .mensaZittau
         default:
             return nil
         }

--- a/Sources/EmealKit/Mensa/MensaAPI.swift
+++ b/Sources/EmealKit/Mensa/MensaAPI.swift
@@ -18,7 +18,6 @@ extension Canteen {
         Logger.emealKit.debug("Fetching all canteens")
         do {
             let (data, _) = try await session.data(from: URL.Mensa.canteens)
-            print(String(data: data, encoding: .utf8)!)
             var canteens = try JSONDecoder().decode([Canteen].self, from: data)
             Logger.emealKit.debug("Successfully fetched \(canteens.count) canteens")
             

--- a/Sources/EmealKit/Mensa/OpeningHours.swift
+++ b/Sources/EmealKit/Mensa/OpeningHours.swift
@@ -162,8 +162,10 @@ public struct OpeningHours: Equatable, Codable {
         }
         
         public func isActive(on date: Date = Date()) -> Bool {
-            if let from = from, date < from { return false }
-            if let to = to, date > to { return false }
+            let calendar = OpeningHoursDateContext.calendar
+            let day = calendar.startOfDay(for: date)
+            if let from = from, day < calendar.startOfDay(for: from) { return false }
+            if let to = to, day > calendar.startOfDay(for: to) { return false }
             return true
         }
     }
@@ -188,7 +190,7 @@ public struct OpeningHours: Equatable, Codable {
         
         /// Check if open at a specific date/time
         public func isOpen(at date: Date = Date()) -> Bool {
-            let calendar = Calendar.current
+            let calendar = OpeningHoursDateContext.calendar
             guard let weekday = Weekday.from(date: date, calendar: calendar) else { return false }
             let time = TimeOfDay.from(date: date, calendar: calendar)
             return isOpen(on: weekday, at: time)
@@ -198,18 +200,18 @@ public struct OpeningHours: Equatable, Codable {
         public func closingTime(from date: Date = Date()) -> Date? {
             guard isOpen(at: date) else { return nil }
             
-            let calendar = Calendar.current
+            let calendar = OpeningHoursDateContext.calendar
             var components = calendar.dateComponents([.year, .month, .day], from: date)
             components.hour = closeTime.hour
             components.minute = closeTime.minute
-            components.timeZone = TimeZone(identifier: "Europe/Berlin")
+            components.timeZone = OpeningHoursDateContext.berlinTimeZone
             
             return calendar.date(from: components)
         }
         
         /// Get next opening time from given date
         public func openingTime(from date: Date = Date()) -> Date? {
-            let calendar = Calendar.current
+            let calendar = OpeningHoursDateContext.calendar
             let currentWeekday = Weekday.from(date: date, calendar: calendar)
             let currentTime = TimeOfDay.from(date: date, calendar: calendar)
             
@@ -218,7 +220,7 @@ public struct OpeningHours: Equatable, Codable {
                 var components = calendar.dateComponents([.year, .month, .day], from: date)
                 components.hour = openTime.hour
                 components.minute = openTime.minute
-                components.timeZone = TimeZone(identifier: "Europe/Berlin")
+                components.timeZone = OpeningHoursDateContext.berlinTimeZone
                 return calendar.date(from: components)
             }
             
@@ -233,7 +235,7 @@ public struct OpeningHours: Equatable, Codable {
                 var components = calendar.dateComponents([.year, .month, .day], from: futureDate)
                 components.hour = openTime.hour
                 components.minute = openTime.minute
-                components.timeZone = TimeZone(identifier: "Europe/Berlin")
+                components.timeZone = OpeningHoursDateContext.berlinTimeZone
                 
                 return calendar.date(from: components)
             }

--- a/Sources/EmealKit/Mensa/OpeningHours.swift
+++ b/Sources/EmealKit/Mensa/OpeningHours.swift
@@ -1,0 +1,417 @@
+import Foundation
+
+// MARK: - Data Models
+
+public struct OpeningHours: Equatable, Codable {
+    public let canteenName: String
+    public let regularHours: [TimeSlot]
+    public let changedHours: [TimeSlot]
+    
+    public init(canteenName: String, regularHours: [TimeSlot], changedHours: [TimeSlot]) {
+        self.canteenName = canteenName
+        self.regularHours = regularHours
+        self.changedHours = changedHours
+    }
+    
+    /// Check if the canteen is open at a specific date/time
+    public func isOpen(at date: Date = Date()) -> Bool {
+        // Check changed hours first (they override regular hours)
+        for slot in changedHours {
+            if slot.isOpen(at: date) {
+                return true
+            }
+        }
+        
+        if (!changedHours.isEmpty) {
+            return false
+        }
+        
+        // Fall back to regular hours
+        for slot in regularHours {
+            if slot.isOpen(at: date) {
+                return true
+            }
+        }
+        
+        return false
+    }
+    
+    /// Check if there are changed opening hours active at a specific date
+    public func hasChangedHours(at date: Date = Date()) -> Bool {
+        for slot in changedHours {
+            if let dateRange = slot.dateRange, dateRange.isActive(on: date) {
+                return true
+            }
+        }
+        return false
+    }
+    
+    /// Get the time when the canteen closes next (if currently open)
+    /// Returns the EARLIEST closing time of any open service (Urgency).
+    public func closingTime(from date: Date = Date()) -> (Date?, String?) {
+        var activeSlots: [TimeSlot] = []
+        let collectSlots = { (slot: TimeSlot) in
+            if let dateRange = slot.dateRange, !dateRange.isActive(on: date) { return }
+            activeSlots.append(slot)
+        }
+        changedHours.forEach(collectSlots)
+        regularHours.forEach(collectSlots)
+        
+        let openSlots = activeSlots.filter { $0.isOpen(at: date) }
+        
+        // Sort by closing time (Earliest closing time first)
+        let sortedSlots = openSlots.sorted { slot1, slot2 in
+            guard let close1 = slot1.closingTime(from: date), let close2 = slot2.closingTime(from: date) else { return false }
+            return close1 < close2
+        }
+        
+        if let bestSlot = sortedSlots.first {
+             return (bestSlot.closingTime(from: date), bestSlot.area)
+        }
+        
+        return (nil, nil)
+    }
+    
+    /// Get the time when the canteen opens next (if currently closed)
+    /// Returns the EARLIEST opening time of any service.
+    public func openingTime(from date: Date = Date()) -> (Date?, String?) {
+        var candidates: [(date: Date, slot: TimeSlot)] = []
+        
+        let checkSlots = { (slots: [TimeSlot]) in
+            for slot in slots {
+                if let range = slot.dateRange, !range.isActive(on: date) { continue }
+                // Use the modified openingTime which finds the *closest* next opening time
+                // This will handle opening later today vs tomorrow correctly
+                if let openTime = slot.openingTime(from: date) {
+                    candidates.append((openTime, slot))
+                }
+            }
+        }
+        
+        checkSlots(changedHours)
+        checkSlots(regularHours)
+        
+        guard !candidates.isEmpty else { return (nil, nil) }
+        
+        // Sort by time (earliest wins)
+        candidates.sort { $0.date < $1.date }
+        
+        if let best = candidates.first {
+            return (best.date, best.slot.area)
+        }
+        
+        return (nil, nil)
+    }
+    
+    public struct TimeSlot: Equatable, Codable {
+        public let area: String
+        public let dateRange: DateRange?
+        public let hoursText: String
+        public let isRegular: Bool
+        public let parsedHours: [WeekdayHours]
+        
+        public init(area: String, dateRange: DateRange?, hoursText: String, isRegular: Bool, parsedHours: [WeekdayHours]) {
+            self.area = area
+            self.dateRange = dateRange
+            self.hoursText = hoursText
+            self.isRegular = isRegular
+            self.parsedHours = parsedHours
+        }
+        
+        /// Check if this time slot is active and open at a specific date/time
+        public func isOpen(at date: Date = Date()) -> Bool {
+            // Check if date range is active
+            if let dateRange = dateRange, !dateRange.isActive(on: date) {
+                return false
+            }
+            
+            // Check if any parsed hours match
+            for hours in parsedHours {
+                if hours.isOpen(at: date) {
+                    return true
+                }
+            }
+            
+            return false
+        }
+        
+        /// Get closing time if currently open
+        public func closingTime(from date: Date = Date()) -> Date? {
+            // Check if date range is active (if present)
+            if let dateRange = dateRange, !dateRange.isActive(on: date) {
+                return nil
+            }
+            
+            for hours in parsedHours {
+                if hours.isOpen(at: date) {
+                    return hours.closingTime(from: date)
+                }
+            }
+            
+            return nil
+        }
+        
+        /// Get next opening time if currently closed
+        public func openingTime(from date: Date = Date()) -> Date? {
+            // Check if date range is active (if present)
+            if let dateRange = dateRange, !dateRange.isActive(on: date) {
+                return nil
+            }
+            
+            // Find the earliest opening time
+            var earliest: Date?
+            for hours in parsedHours {
+                if let openTime = hours.openingTime(from: date) {
+                    if let current = earliest {
+                        if openTime < current {
+                            earliest = openTime
+                        }
+                    } else {
+                        earliest = openTime
+                    }
+                }
+            }
+            
+            return earliest
+        }
+    }
+    
+    public struct DateRange: Equatable, Codable {
+        public let from: Date?
+        public let to: Date?
+        public let text: String
+        
+        public init(from: Date?, to: Date?, text: String) {
+            self.from = from
+            self.to = to
+            self.text = text
+        }
+        
+        public func isActive(on date: Date = Date()) -> Bool {
+            if let from = from, date < from { return false }
+            if let to = to, date > to { return false }
+            return true
+        }
+    }
+    
+    public struct WeekdayHours: Equatable, Codable {
+        public let label: String?  // e.g. "Mittagstisch im Brat²", "Cafeteria Zebradiele"
+        public let days: Set<Weekday>
+        public let openTime: TimeOfDay
+        public let closeTime: TimeOfDay
+        
+        public init(label: String? = nil, days: Set<Weekday>, openTime: TimeOfDay, closeTime: TimeOfDay) {
+            self.label = label
+            self.days = days
+            self.openTime = openTime
+            self.closeTime = closeTime
+        }
+        
+        public func isOpen(on weekday: Weekday, at time: TimeOfDay) -> Bool {
+            guard days.contains(weekday) else { return false }
+            return time >= openTime && time <= closeTime
+        }
+        
+        /// Check if open at a specific date/time
+        public func isOpen(at date: Date = Date()) -> Bool {
+            let calendar = Calendar.current
+            guard let weekday = Weekday.from(date: date, calendar: calendar) else { return false }
+            let time = TimeOfDay.from(date: date, calendar: calendar)
+            return isOpen(on: weekday, at: time)
+        }
+        
+        /// Get closing time if currently open, nil otherwise
+        public func closingTime(from date: Date = Date()) -> Date? {
+            guard isOpen(at: date) else { return nil }
+            
+            let calendar = Calendar.current
+            var components = calendar.dateComponents([.year, .month, .day], from: date)
+            components.hour = closeTime.hour
+            components.minute = closeTime.minute
+            components.timeZone = TimeZone(identifier: "Europe/Berlin")
+            
+            return calendar.date(from: components)
+        }
+        
+        /// Get next opening time from given date
+        public func openingTime(from date: Date = Date()) -> Date? {
+            let calendar = Calendar.current
+            let currentWeekday = Weekday.from(date: date, calendar: calendar)
+            let currentTime = TimeOfDay.from(date: date, calendar: calendar)
+            
+            // Check if we can open today
+            if let weekday = currentWeekday, days.contains(weekday), currentTime < openTime {
+                var components = calendar.dateComponents([.year, .month, .day], from: date)
+                components.hour = openTime.hour
+                components.minute = openTime.minute
+                components.timeZone = TimeZone(identifier: "Europe/Berlin")
+                return calendar.date(from: components)
+            }
+            
+            // Find next day we're open
+            for daysAhead in 1...7 {
+                guard let futureDate = calendar.date(byAdding: .day, value: daysAhead, to: date),
+                      let weekday = Weekday.from(date: futureDate, calendar: calendar),
+                      days.contains(weekday) else {
+                    continue
+                }
+                
+                var components = calendar.dateComponents([.year, .month, .day], from: futureDate)
+                components.hour = openTime.hour
+                components.minute = openTime.minute
+                components.timeZone = TimeZone(identifier: "Europe/Berlin")
+                
+                return calendar.date(from: components)
+            }
+            
+            return nil
+        }
+    }
+    
+    public struct TimeOfDay: Equatable, Codable, Comparable {
+        public let hour: Int
+        public let minute: Int
+        
+        public init(hour: Int, minute: Int) {
+            self.hour = hour
+            self.minute = minute
+        }
+        
+        public var totalMinutes: Int {
+            hour * 60 + minute
+        }
+        
+        public static func < (lhs: TimeOfDay, rhs: TimeOfDay) -> Bool {
+            lhs.totalMinutes < rhs.totalMinutes
+        }
+        
+        public var formatted: String {
+            String(format: "%02d:%02d", hour, minute)
+        }
+        
+        /// Create TimeOfDay from a Date
+        public static func from(date: Date, calendar: Calendar = Calendar.current) -> TimeOfDay {
+            let hour = calendar.component(.hour, from: date)
+            let minute = calendar.component(.minute, from: date)
+            return TimeOfDay(hour: hour, minute: minute)
+        }
+    }
+    
+    /// Get statuses for all active services at a specific date
+    public func serviceStatuses(at date: Date = Date()) -> [ServiceStatus] {
+        var statuses: [ServiceStatus] = []
+        
+        let processSlots = { (slots: [TimeSlot]) in
+            for slot in slots {
+                if let range = slot.dateRange, !range.isActive(on: date) { continue }
+                
+                if slot.isOpen(at: date) {
+                    if let closeDate = slot.closingTime(from: date) {
+                        statuses.append(ServiceStatus(
+                            area: slot.area,
+                            isOpen: true,
+                            timeUntilChange: closeDate.timeIntervalSince(date),
+                            changeTime: closeDate,
+                            totalDuration: slot.parsedHours.first(where: { $0.isOpen(at: date) })
+                                .map { $0.closeTime.totalMinutes - $0.openTime.totalMinutes }
+                                .map { TimeInterval($0 * 60) } ?? 3600
+                        ))
+                    }
+                } else {
+                    if let openDate = slot.openingTime(from: date) {
+                         statuses.append(ServiceStatus(
+                            area: slot.area,
+                            isOpen: false,
+                            timeUntilChange: openDate.timeIntervalSince(date),
+                            changeTime: openDate,
+                            totalDuration: 0 // Not relevant for closed
+                        ))
+                    }
+                }
+            }
+        }
+        
+        processSlots(changedHours)
+        processSlots(regularHours)
+        
+        // Deduplicate by area (prefer open ones, then earlier ones)
+        // If we have "Lunch" in changed and regular, we likely only want one.
+        var uniqueStatuses: [String: ServiceStatus] = [:]
+        for status in statuses {
+            if let existing = uniqueStatuses[status.area] {
+                // If existing is closed and new is open, replace
+                if !existing.isOpen && status.isOpen {
+                    uniqueStatuses[status.area] = status
+                }
+                // If both open/closed, take the one with earlier change time (more urgent)
+                else if existing.isOpen == status.isOpen && status.timeUntilChange < existing.timeUntilChange {
+                    uniqueStatuses[status.area] = status
+                }
+            } else {
+                uniqueStatuses[status.area] = status
+            }
+        }
+        
+        return Array(uniqueStatuses.values).sorted {
+            if $0.isOpen != $1.isOpen { return $0.isOpen } // Open first
+            return $0.timeUntilChange < $1.timeUntilChange
+        }
+    }
+    
+    public struct ServiceStatus: Identifiable {
+        public let id = UUID()
+        public let area: String
+        public let isOpen: Bool
+        public let timeUntilChange: TimeInterval
+        public let changeTime: Date
+        public let totalDuration: TimeInterval
+    }
+    
+    public enum Weekday: String, Codable, CaseIterable, Hashable {
+        case monday = "Mo"
+        case tuesday = "Di"
+        case wednesday = "Mi"
+        case thursday = "Do"
+        case friday = "Fr"
+        case saturday = "Sa"
+        case sunday = "So"
+        
+        public var fullName: String {
+            switch self {
+            case .monday: return "Montag"
+            case .tuesday: return "Dienstag"
+            case .wednesday: return "Mittwoch"
+            case .thursday: return "Donnerstag"
+            case .friday: return "Freitag"
+            case .saturday: return "Samstag"
+            case .sunday: return "Sonntag"
+            }
+        }
+        
+        public static func from(germanName: String) -> Weekday? {
+            let normalized = germanName.lowercased().trimmingCharacters(in: .whitespaces)
+            for day in Weekday.allCases {
+                if day.fullName.lowercased() == normalized {
+                    return day
+                }
+            }
+            return nil
+        }
+        
+        /// Create Weekday from a Date
+        public static func from(date: Date, calendar: Calendar = Calendar.current) -> Weekday? {
+            let weekdayNum = calendar.component(.weekday, from: date)
+            // Calendar.component(.weekday) returns 1 for Sunday, 2 for Monday, etc.
+            switch weekdayNum {
+            case 1: return .sunday
+            case 2: return .monday
+            case 3: return .tuesday
+            case 4: return .wednesday
+            case 5: return .thursday
+            case 6: return .friday
+            case 7: return .saturday
+            default: return nil
+            }
+        }
+    }
+}

--- a/Sources/EmealKit/Mensa/OpeningHoursDateContext.swift
+++ b/Sources/EmealKit/Mensa/OpeningHoursDateContext.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum OpeningHoursDateContext {
+    static let berlinTimeZone = TimeZone(identifier: "Europe/Berlin") ?? .current
+
+    static var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = berlinTimeZone
+        return calendar
+    }
+}

--- a/Sources/EmealKit/Mensa/OpeningHoursParser.swift
+++ b/Sources/EmealKit/Mensa/OpeningHoursParser.swift
@@ -312,7 +312,7 @@ struct OpeningHoursParser {
     static func inferYear(start: Date?, end: Date?) -> (Date?, Date?) {
         guard let start = start, let end = end else { return (start, end) }
         
-        let calendar = Calendar.current
+        let calendar = OpeningHoursDateContext.calendar
         let startYear = calendar.component(.year, from: start)
         let endYear = calendar.component(.year, from: end)
         
@@ -321,7 +321,7 @@ struct OpeningHoursParser {
         if endYear != startYear || (endYear == startYear && start > end) {
             var components = calendar.dateComponents([.day, .month], from: start)
             components.year = endYear - 1
-            components.timeZone = TimeZone(identifier: "Europe/Berlin")
+            components.timeZone = OpeningHoursDateContext.berlinTimeZone
             if let newStart = calendar.date(from: components) {
                 return (newStart, end)
             }
@@ -424,7 +424,7 @@ struct OpeningHoursParser {
         } else {
             // No year provided - assume current or next year based on month
             let now = Date()
-            let calendar = Calendar.current
+            let calendar = OpeningHoursDateContext.calendar
             let currentYear = calendar.component(.year, from: now)
             let currentMonth = calendar.component(.month, from: now)
             
@@ -440,8 +440,8 @@ struct OpeningHoursParser {
         dateComponents.day = day
         dateComponents.month = month
         dateComponents.year = year
-        dateComponents.timeZone = TimeZone(identifier: "Europe/Berlin")
+        dateComponents.timeZone = OpeningHoursDateContext.berlinTimeZone
         
-        return Calendar.current.date(from: dateComponents)
+        return OpeningHoursDateContext.calendar.date(from: dateComponents)
     }
 }

--- a/Sources/EmealKit/Mensa/OpeningHoursParser.swift
+++ b/Sources/EmealKit/Mensa/OpeningHoursParser.swift
@@ -316,15 +316,6 @@ struct OpeningHoursParser {
         let startYear = calendar.component(.year, from: start)
         let endYear = calendar.component(.year, from: end)
         
-        /*if start > end && startYear == endYear {
-            var components = calendar.dateComponents([.day, .month], from: start)
-            components.year = endYear + 1
-            components.timeZone = TimeZone(identifier: "Europe/Berlin")
-            if let newStart = calendar.date(from: components) {
-                return (newStart, end)
-            }
-        }*/
-        
         // If explicit end year provided (e.g. 2026) and start inferred current year (e.g. 2025),
         // update start to match end year.
         if endYear != startYear || (endYear == startYear && start > end) {

--- a/Sources/EmealKit/Mensa/OpeningHoursParser.swift
+++ b/Sources/EmealKit/Mensa/OpeningHoursParser.swift
@@ -1,0 +1,456 @@
+import Foundation
+import Regex
+
+/// Parses German opening hours text into structured data
+struct OpeningHoursParser {
+    
+    // MARK: - Weekday Parsing
+    
+    /// Parses weekday ranges like "Mo-Fr", "Mo - Do", "Montag - Freitag"
+    static func parseWeekdays(_ text: String) -> Set<OpeningHours.Weekday> {
+        let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        var result = Set<OpeningHours.Weekday>()
+        
+        // Try range patterns: "Mo-Fr", "Mo - Fr", "Montag - Freitag"
+        if let days = parseWeekdayRange(normalized) {
+            return days
+        }
+        
+        // Try comma-separated: "Mo, Mi, Fr"
+        if normalized.contains(",") {
+            let parts = normalized.components(separatedBy: ",")
+            for part in parts {
+                if let day = parseSingleWeekday(part.trimmingCharacters(in: .whitespaces)) {
+                    result.insert(day)
+                }
+            }
+            if !result.isEmpty {
+                return result
+            }
+        }
+        
+        // Try single weekday
+        if let day = parseSingleWeekday(normalized) {
+            result.insert(day)
+        }
+        
+        return result
+    }
+    
+    private static func parseWeekdayRange(_ text: String) -> Set<OpeningHours.Weekday>? {
+        // Pattern: "Mo-Fr" or "Mo - Fr" or "Montag - Freitag"
+        let rangeRegex = Regex(#"(\w+)\s*-\s*(\w+)"#)
+        guard let match = rangeRegex.firstMatch(in: text),
+              let startText = match.captures[0],
+              let endText = match.captures[1],
+              let start = parseSingleWeekday(startText),
+              let end = parseSingleWeekday(endText) else {
+            return nil
+        }
+        
+        // Get all days between start and end
+        let allDays = OpeningHours.Weekday.allCases
+        guard let startIdx = allDays.firstIndex(of: start),
+              let endIdx = allDays.firstIndex(of: end) else {
+            return nil
+        }
+        
+        if startIdx <= endIdx {
+            return Set(allDays[startIdx...endIdx])
+        } else {
+            // Wrap around (e.g., Fr-Mo would be Fr, Sa, So, Mo)
+            return Set(allDays[startIdx...] + allDays[...endIdx])
+        }
+    }
+    
+    private static func parseSingleWeekday(_ text: String) -> OpeningHours.Weekday? {
+        let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        // Try short form (Mo, Di, etc.)
+        if let day = OpeningHours.Weekday(rawValue: normalized) {
+            return day
+        }
+        
+        // Try full German name
+        return OpeningHours.Weekday.from(germanName: normalized)
+    }
+    
+    // MARK: - Time Parsing
+    
+    /// Parses time strings like "11:00", "11.00", "11:00 Uhr"
+    static func parseTime(_ text: String) -> OpeningHours.TimeOfDay? {
+        let normalized = text.trimmingCharacters(in: .whitespaces)
+            .replacingOccurrences(of: "Uhr", with: "")
+            .trimmingCharacters(in: .whitespaces)
+        
+        // Pattern: "11:00" or "11.00"
+        let timeRegex = Regex(#"(\d{1,2})[:.](\d{2})"#)
+        guard let match = timeRegex.firstMatch(in: normalized),
+              let hourStr = match.captures[0],
+              let minuteStr = match.captures[1],
+              let hour = Int(hourStr),
+              let minute = Int(minuteStr),
+              hour >= 0 && hour < 24,
+              minute >= 0 && minute < 60 else {
+            return nil
+        }
+        
+        return OpeningHours.TimeOfDay(hour: hour, minute: minute)
+    }
+    
+    /// Parses time ranges like "11:00 - 14:00", "von 8:00 bis 17:00 Uhr"
+    static func parseTimeRange(_ text: String) -> (OpeningHours.TimeOfDay, OpeningHours.TimeOfDay)? {
+        var normalized = text.trimmingCharacters(in: .whitespaces)
+        
+        // Handle "von X bis Y" format by converting to "X - Y"
+        if normalized.lowercased().contains("von") && normalized.lowercased().contains("bis") {
+            // Pattern: "von 8:00 bis 17:00"
+            let vonBisPattern = Regex(#"von\s+(\d{1,2}[:\.]\d{2})\s+bis\s+(\d{1,2}[:\.]\d{2})"#)
+            if let match = vonBisPattern.firstMatch(in: normalized),
+               let openStr = match.captures[0],
+               let closeStr = match.captures[1],
+               let openTime = parseTime(openStr),
+               let closeTime = parseTime(closeStr) {
+                return (openTime, closeTime)
+            }
+        }
+        
+        // Remove German prepositions for standard format
+        normalized = normalized.replacingOccurrences(of: "von ", with: "")
+        normalized = normalized.replacingOccurrences(of: "bis ", with: "")
+        
+        // Pattern: "11:00 - 14:00" or "11:00-14:00"
+        let components = normalized.components(separatedBy: "-")
+        guard components.count == 2,
+              let openTime = parseTime(components[0]),
+              let closeTime = parseTime(components[1]) else {
+            return nil
+        }
+        
+        return (openTime, closeTime)
+    }
+    
+    // MARK: - Complex Hours Parsing
+    
+    /// Parses complete hours text like "Mo - Fr 11:00 - 14:00 Uhr" or complex cases with multiple time ranges
+    /// The label parameter is the area/service name from the table (e.g., "Mittagstisch im Brat²")
+    static func parseHoursText(_ text: String, label: String? = nil) -> [OpeningHours.WeekdayHours] {
+        var result: [OpeningHours.WeekdayHours] = []
+        
+        // Handle "closed" / "geschlossen"
+        let lowerText = text.lowercased()
+        if lowerText.contains("geschlossen") || lowerText.contains("closed") {
+            return []
+        }
+        
+        // First, try to find all time ranges in the text
+        // Allow optional "Uhr" inside the range, e.g. "17:30 Uhr - 20:00 Uhr"
+        let timeRangePattern = Regex(#"(\d{1,2}[:\.]\d{2})(?:\s+Uhr)?\s*-\s*(\d{1,2}[:\.]\d{2})"#)
+        let vonBisPattern = Regex(#"von\s+(\d{1,2}[:\.]\d{2})\s+bis\s+(\d{1,2}[:\.]\d{2})"#)
+        
+        let timeMatches = timeRangePattern.allMatches(in: text)
+        let vonBisMatches = vonBisPattern.allMatches(in: text)
+        
+        if timeMatches.count == 0 && vonBisMatches.count == 0 {
+            return []
+        }
+        
+        // Strategy: Find weekday ranges, then associate following time ranges with them
+        
+        // Split by newlines first (handles multi-line entries)
+        let lines = text.components(separatedBy: "\n")
+        var currentContextDays: Set<OpeningHours.Weekday>? = nil
+        
+        for line in lines {
+            let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+            if trimmedLine.isEmpty { continue }
+            
+            // Try to parse this line
+            let (lineResults, lastDays) = parseLine(trimmedLine, label: label, initialContextDays: currentContextDays)
+            result.append(contentsOf: lineResults)
+            
+            // Update context for next line if we found days
+            if let days = lastDays {
+                currentContextDays = days
+            }
+        }
+        
+        // If nothing was parsed from lines (and we had newlines?), try the whole text as fallback if result is empty
+        // But parseLine logic already handles single line correctly.
+        // If result is empty but we had matches, maybe newline split broke it?
+        // But typically lines work better.
+        
+        return result
+    }
+    
+    /// Parses a single line which may contain multiple time ranges
+    /// Returns the parsed hours and the last active weekdays found (for context propagation)
+    private static func parseLine(_ line: String, label: String?, initialContextDays: Set<OpeningHours.Weekday>? = nil) -> ([OpeningHours.WeekdayHours], Set<OpeningHours.Weekday>?) {
+        var result: [OpeningHours.WeekdayHours] = []
+        
+        // Find all time ranges to check if line is relevant
+        let timeRangePattern = Regex(#"(\d{1,2}[:\.]\d{2})(?:\s+Uhr)?\s*-\s*(\d{1,2}[:\.]\d{2})"#)
+        let vonBisPattern = Regex(#"von\s+(\d{1,2}[:\.]\d{2})\s+bis\s+(\d{1,2}[:\.]\d{2})"#)
+        
+        let timeMatches = timeRangePattern.allMatches(in: line)
+        let vonBisMatches = vonBisPattern.allMatches(in: line)
+        
+        if timeMatches.isEmpty && vonBisMatches.isEmpty {
+            return ([], initialContextDays)
+        }
+        
+        // Strategy: Look for pattern changes
+        // If we see "... und Fr von ..." it means new weekdays
+        // If we see "... und 15:30 - 18:30" (just time, no weekdays), same weekdays
+        
+        // Split by " und " to find segments
+        let segments = line.components(separatedBy: " und ")
+        
+        // Track current days for this line
+        var currentDays: Set<OpeningHours.Weekday>? = initialContextDays
+        
+        for segment in segments {
+            let trimmed = segment.trimmingCharacters(in: .whitespaces)
+            
+            // Try to find weekdays in this segment
+            let segmentDays = extractWeekdaysFromSegment(trimmed)
+            
+            if !segmentDays.isEmpty {
+                // New weekdays found - use them
+                currentDays = segmentDays
+            } 
+            // else: no weekdays found, reuse currentDays
+            
+            // Now parse time range from this segment
+            if let hours = parseSingleHoursSegment(trimmed, label: label, forceDays: currentDays) {
+                result.append(hours)
+                // Remember the days for next segment
+                currentDays = hours.days
+            }
+        }
+        
+        return (result, currentDays)
+    }
+    
+    /// Extracts weekdays from a text segment without parsing times
+    private static func extractWeekdaysFromSegment(_ text: String) -> Set<OpeningHours.Weekday> {
+        // Remove time patterns to avoid confusion
+        var cleaned = text
+        
+        // Remove "von X bis Y" patterns first
+        let vonBisPattern = Regex(#"von\s+\d{1,2}[:\.]\d{2}\s+bis\s+\d{1,2}[:\.]\d{2}"#)
+        for match in vonBisPattern.allMatches(in: cleaned).reversed() {
+            let range = match.range
+            cleaned.removeSubrange(range)
+        }
+        
+        // Remove all standard time patterns like "10:45 - 14:00" or "17:30 Uhr - 20:00"
+        let timePattern = Regex(#"\d{1,2}[:\.]\d{2}(?:\s+Uhr)?\s*-\s*\d{1,2}[:\.]\d{2}"#)
+        for match in timePattern.allMatches(in: cleaned).reversed() {
+            let range = match.range
+            cleaned.removeSubrange(range)
+        }
+        
+        // Remove common words
+        cleaned = cleaned.replacingOccurrences(of: "von ", with: "")
+        cleaned = cleaned.replacingOccurrences(of: "bis ", with: "")
+        cleaned = cleaned.replacingOccurrences(of: "Uhr", with: "")
+        
+        return parseWeekdays(cleaned)
+    }
+    
+    /// Parses a single segment like "Mo - Fr 11:00 - 14:00 Uhr"
+    /// If forceDays is provided, use those days instead of parsing
+    private static func parseSingleHoursSegment(_ text: String, label: String?, forceDays: Set<OpeningHours.Weekday>? = nil) -> OpeningHours.WeekdayHours? {
+        // Try to find time range - handle both "X - Y" and "von X bis Y" patterns
+        var openTime: OpeningHours.TimeOfDay?
+        var closeTime: OpeningHours.TimeOfDay?
+        
+        // First try "von X bis Y" pattern
+        let vonBisPattern = Regex(#"von\s+(\d{1,2}[:\.]\d{2})\s+bis\s+(\d{1,2}[:\.]\d{2})"#)
+        if let vonBisMatch = vonBisPattern.firstMatch(in: text),
+           let openStr = vonBisMatch.captures[0],
+           let closeStr = vonBisMatch.captures[1] {
+            openTime = parseTime(openStr)
+            closeTime = parseTime(closeStr)
+        }
+        
+        // If not found, try standard "X - Y" pattern
+        if openTime == nil || closeTime == nil {
+            let timeRangePattern = Regex(#"(\d{1,2}[:\.]\d{2})(?:\s+Uhr)?\s*-\s*(\d{1,2}[:\.]\d{2})"#)
+            if let timeMatch = timeRangePattern.firstMatch(in: text),
+               let openTimeStr = timeMatch.captures[0],
+               let closeTimeStr = timeMatch.captures[1] {
+                openTime = parseTime(openTimeStr)
+                closeTime = parseTime(closeTimeStr)
+            }
+        }
+        
+        guard let open = openTime, let close = closeTime else {
+            return nil
+        }
+        
+        // Use forced days if provided, otherwise extract from text
+        let days: Set<OpeningHours.Weekday>
+        if let forceDays = forceDays {
+            days = forceDays
+        } else {
+            // Extract weekdays from the text
+            days = extractWeekdaysFromSegment(text)
+        }
+        
+        guard !days.isEmpty else {
+            return nil
+        }
+        
+        return OpeningHours.WeekdayHours(label: label, days: days, openTime: open, closeTime: close)
+    }
+    
+    // MARK: - Date Range Parsing
+    
+    /// Infers year for start date based on end date if they differ
+    static func inferYear(start: Date?, end: Date?) -> (Date?, Date?) {
+        guard let start = start, let end = end else { return (start, end) }
+        
+        let calendar = Calendar.current
+        let startYear = calendar.component(.year, from: start)
+        let endYear = calendar.component(.year, from: end)
+        
+        /*if start > end && startYear == endYear {
+            var components = calendar.dateComponents([.day, .month], from: start)
+            components.year = endYear + 1
+            components.timeZone = TimeZone(identifier: "Europe/Berlin")
+            if let newStart = calendar.date(from: components) {
+                return (newStart, end)
+            }
+        }*/
+        
+        // If explicit end year provided (e.g. 2026) and start inferred current year (e.g. 2025),
+        // update start to match end year.
+        if endYear != startYear || (endYear == startYear && start > end) {
+            var components = calendar.dateComponents([.day, .month], from: start)
+            components.year = endYear - 1
+            components.timeZone = TimeZone(identifier: "Europe/Berlin")
+            if let newStart = calendar.date(from: components) {
+                return (newStart, end)
+            }
+        }
+        
+        return (start, end)
+    }
+    
+    /// Parses date ranges like "09.02.26 - 20.02.26", "bis 03.02.26", "ab 06.06.25"
+    /// Also handles: "vom 02.02. bis 03.02.2026" (mixed formats with/without year)
+    static func parseDateRange(_ text: String) -> OpeningHours.DateRange? {
+        let normalized = text.trimmingCharacters(in: .whitespaces)
+        
+        // Empty string
+        if normalized.isEmpty {
+            return nil
+        }
+        
+        // Pattern: "vom DD.MM. bis DD.MM.YYYY" or "vom DD.MM.YY bis DD.MM.YYYY"
+        let vonBisPattern = Regex(#"vom\s+(\d{2}\.\d{2}\.(?:\d{2,4})?)\s+bis\s+(\d{2}\.\d{2}\.(?:\d{2,4})?)"#)
+        if let match = vonBisPattern.firstMatch(in: normalized),
+           let startStr = match.captures[0],
+           let endStr = match.captures[1] {
+            var startDate = parseGermanDate(startStr)
+            var endDate = parseGermanDate(endStr)
+            
+            // Fix year inference if mixed precision
+            (startDate, endDate) = inferYear(start: startDate, end: endDate)
+            
+            return OpeningHours.DateRange(from: startDate, to: endDate, text: normalized)
+        }
+        
+        // Pattern: "DD.MM.YY - DD.MM.YY" or "DD.MM.YYYY - DD.MM.YYYY"
+        // Also: "DD.MM. - DD.MM.YYYY"
+        let rangeRegex = Regex(#"(\d{2}\.\d{2}\.(?:\d{2,4})?)\s*-\s*(\d{2}\.\d{2}\.(?:\d{2,4})?)"#)
+        if let match = rangeRegex.firstMatch(in: normalized),
+           let startStr = match.captures[0],
+           let endStr = match.captures[1] {
+            var startDate = parseGermanDate(startStr)
+            var endDate = parseGermanDate(endStr)
+            
+            // Fix year inference
+            (startDate, endDate) = inferYear(start: startDate, end: endDate)
+            
+            return OpeningHours.DateRange(from: startDate, to: endDate, text: normalized)
+        }
+        
+        // Pattern: "bis DD.MM.YY" or "bis DD.MM.YYYY" or "bis DD.MM."
+        let untilRegex = Regex(#"bis\s+(\d{2}\.\d{2}\.(?:\d{2,4})?)"#)
+        if let match = untilRegex.firstMatch(in: normalized),
+           let dateStr = match.captures[0] {
+            let date = parseGermanDate(dateStr)
+            return OpeningHours.DateRange(from: nil, to: date, text: normalized)
+        }
+        
+        // Pattern: "ab DD.MM.YY" or "ab DD.MM.YYYY" or "ab DD.MM."
+        let fromRegex = Regex(#"ab\s+(\d{2}\.\d{2}\.(?:\d{2,4})?)"#)
+        if let match = fromRegex.firstMatch(in: normalized),
+           let dateStr = match.captures[0] {
+            let date = parseGermanDate(dateStr)
+            return OpeningHours.DateRange(from: date, to: nil, text: normalized)
+        }
+        
+        // Single date: "DD.MM.YY" or "DD.MM.YYYY" or "DD.MM."
+        let dateRegex = Regex(#"(\d{2}\.\d{2}\.(?:\d{2,4})?)"#)
+        if let match = dateRegex.firstMatch(in: normalized),
+           let dateStr = match.captures[0] {
+            let date = parseGermanDate(dateStr)
+            return OpeningHours.DateRange(from: date, to: date, text: normalized)
+        }
+        
+        // Couldn't parse, but has text - return as-is for display
+        return OpeningHours.DateRange(from: nil, to: nil, text: normalized)
+    }
+    
+    /// Parses German date format into Date
+    /// Supports: "DD.MM.YY", "DD.MM.YYYY", "DD.MM." (no year - assumes current/next year)
+    private static func parseGermanDate(_ text: String) -> Date? {
+        let components = text.components(separatedBy: ".")
+        guard components.count >= 2,
+              let day = Int(components[0]),
+              let month = Int(components[1]) else {
+            return nil
+        }
+        
+        let year: Int
+        if components.count >= 3 && !components[2].isEmpty {
+            guard let yearValue = Int(components[2]) else {
+                return nil
+            }
+            
+            // Convert year based on length
+            if yearValue < 100 {
+                // 2-digit year (e.g., "26" -> 2026)
+                year = 2000 + yearValue
+            } else {
+                // 4-digit year (e.g., "2026")
+                year = yearValue
+            }
+        } else {
+            // No year provided - assume current or next year based on month
+            let now = Date()
+            let calendar = Calendar.current
+            let currentYear = calendar.component(.year, from: now)
+            let currentMonth = calendar.component(.month, from: now)
+            
+            // If the month is in the past, assume next year
+            if month < currentMonth {
+                year = currentYear + 1
+            } else {
+                year = currentYear
+            }
+        }
+        
+        var dateComponents = DateComponents()
+        dateComponents.day = day
+        dateComponents.month = month
+        dateComponents.year = year
+        dateComponents.timeZone = TimeZone(identifier: "Europe/Berlin")
+        
+        return Calendar.current.date(from: dateComponents)
+    }
+}

--- a/Sources/EmealKit/Mensa/OpeningHoursScraper.swift
+++ b/Sources/EmealKit/Mensa/OpeningHoursScraper.swift
@@ -34,8 +34,12 @@ struct OpeningHoursScraper {
         Logger.emealKit.debug("Found \(cards.count) canteen cards")
         
         for card in cards {
-            if let openingHours = try? parseCanteenCard(card) {
-                result.append(openingHours)
+            do {
+                if let openingHours = try parseCanteenCard(card) {
+                    result.append(openingHours)
+                }
+            } catch {
+                Logger.emealKit.error("Failed parsing opening-hours card '\(cardName(from: card))': \(String(describing: error))")
             }
         }
         
@@ -135,5 +139,17 @@ struct OpeningHoursScraper {
             regularHours: regularHours,
             changedHours: changedHours
         )
+    }
+
+    private static func cardName(from card: Element) -> String {
+        guard
+            let header = try? card.select("h5.card-header").first(),
+            let rawName = try? header.text()
+        else {
+            return "<unknown>"
+        }
+
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? "<unknown>" : name
     }
 }

--- a/Sources/EmealKit/Mensa/OpeningHoursScraper.swift
+++ b/Sources/EmealKit/Mensa/OpeningHoursScraper.swift
@@ -34,7 +34,7 @@ struct OpeningHoursScraper {
         Logger.emealKit.debug("Found \(cards.count) canteen cards")
         
         for card in cards {
-            if let openingHours = try parseCanteenCard(card) {
+            if let openingHours = try? parseCanteenCard(card) {
                 result.append(openingHours)
             }
         }

--- a/Sources/EmealKit/Mensa/OpeningHoursScraper.swift
+++ b/Sources/EmealKit/Mensa/OpeningHoursScraper.swift
@@ -1,0 +1,139 @@
+import Foundation
+import SwiftSoup
+import os.log
+
+struct OpeningHoursScraper {
+    
+    /// Fetches and parses opening hours from the official page
+    static func fetchOpeningHours(session: URLSessionProtocol = URLSession.shared) async throws -> [OpeningHours] {
+        let url = URL(string: "https://www.studentenwerk-dresden.de/mensen/oeffnungszeiten.html")!
+        
+        Logger.emealKit.debug("Fetching opening hours page")
+        
+        do {
+            let (data, _) = try await session.data(from: url)
+            guard let html = String(data: data, encoding: .utf8) else {
+                Logger.emealKit.error("Failed to decode opening hours HTML")
+                throw EmealError.unknown
+            }
+            
+            return try parseOpeningHours(from: html)
+        } catch {
+            Logger.emealKit.error("Failed to fetch opening hours: \(String(describing: error))")
+            throw error
+        }
+    }
+    
+    /// Parses HTML content to extract opening hours for all canteens
+    static func parseOpeningHours(from html: String) throws -> [OpeningHours] {
+        let document = try SwiftSoup.parse(html)
+        var result: [OpeningHours] = []
+        
+        // Find all canteen cards
+        let cards = try document.select("div.card")
+        Logger.emealKit.debug("Found \(cards.count) canteen cards")
+        
+        for card in cards {
+            if let openingHours = try parseCanteenCard(card) {
+                result.append(openingHours)
+            }
+        }
+        
+        Logger.emealKit.debug("Successfully parsed opening hours for \(result.count) canteens")
+        return result
+    }
+    
+    /// Parses a single canteen card
+    private static func parseCanteenCard(_ card: Element) throws -> OpeningHours? {
+        // Extract canteen name from header
+        guard let headerElement = try card.select("h5.card-header").first(),
+              let canteenName = try? headerElement.text().trimmingCharacters(in: .whitespaces),
+              !canteenName.isEmpty else {
+            Logger.emealKit.debug("Skipping card without valid header")
+            return nil
+        }
+        
+        Logger.emealKit.debug("Parsing opening hours for: \(canteenName)")
+        
+        var regularHours: [OpeningHours.TimeSlot] = []
+        var changedHours: [OpeningHours.TimeSlot] = []
+        
+        // Find all h6 sections (could be regular or changed hours)
+        let sections = try card.select("h6.h5")
+        
+        for section in sections {
+            let sectionTitle = try section.text().lowercased()
+            let isRegular = sectionTitle.contains("reguläre")
+            
+            // Find the table following this section
+            guard let table = try section.nextElementSibling(),
+                  table.tagName() == "table" else {
+                Logger.emealKit.debug("No table found for section: \(sectionTitle)")
+                continue
+            }
+            
+            // Parse table rows
+            let rows = try table.select("tr")
+            for row in rows {
+                let cells = try row.select("th, td")
+                guard cells.count >= 3 else { continue }
+                
+                // Extract cell contents
+                let area = try cells[0].text().trimmingCharacters(in: .whitespaces)
+                let dateRangeText = try cells[1].text().trimmingCharacters(in: .whitespaces)
+                let hoursText = try cells[2].text()
+                    .replacingOccurrences(of: "\n", with: " ")
+                    .replacingOccurrences(of: "  ", with: " ")
+                    .trimmingCharacters(in: .whitespaces)
+                
+                // Parse date range if present
+                var dateRange = dateRangeText.isEmpty ? nil : OpeningHoursParser.parseDateRange(dateRangeText)
+                
+                // Special handling for "Geschlossen vom..." cases where the date range might be in the area column
+                // or split between columns.
+                if (dateRange == nil || dateRange?.from == nil) {
+                    // Try to parse from area text if it looks like a date range
+                    if let areaRange = OpeningHoursParser.parseDateRange(area) {
+                        // If area provided a full range (from & to), prefer it
+                        if areaRange.from != nil && areaRange.to != nil {
+                            dateRange = areaRange
+                        }
+                        // If area provided a start date (from) and we only had an end date (to), merge them?
+                        // E.g. Area: "vom 02.02.", DateCol: "bis 03.02.26"
+                        else if let areaFrom = areaRange.from, let existingTo = dateRange?.to, dateRange?.from == nil {
+                            // Re-infer year since we're merging separate parses
+                            let (fixedFrom, fixedTo) = OpeningHoursParser.inferYear(start: areaFrom, end: existingTo)
+                            dateRange = OpeningHours.DateRange(from: fixedFrom, to: fixedTo, text: area + " " + dateRangeText)
+                        }
+                    }
+                }
+                
+                // Parse hours text into structured data
+                let parsedHours = OpeningHoursParser.parseHoursText(hoursText, label: area)
+                
+                // Create time slot
+                let timeSlot = OpeningHours.TimeSlot(
+                    area: area,
+                    dateRange: dateRange,
+                    hoursText: hoursText,
+                    isRegular: isRegular,
+                    parsedHours: parsedHours
+                )
+                
+                if isRegular {
+                    regularHours.append(timeSlot)
+                } else {
+                    changedHours.append(timeSlot)
+                }
+                
+                Logger.emealKit.debug("  \(isRegular ? "Regular" : "Changed"): \(area) - \(parsedHours.count) parsed slots")
+            }
+        }
+        
+        return OpeningHours(
+            canteenName: canteenName,
+            regularHours: regularHours,
+            changedHours: changedHours
+        )
+    }
+}

--- a/Tests/EmealKitTests/CanteenOpeningHoursIntegrationTests.swift
+++ b/Tests/EmealKitTests/CanteenOpeningHoursIntegrationTests.swift
@@ -3,39 +3,14 @@ import XCTest
 
 /// Integration test to verify opening hours are matched to canteens
 final class CanteenOpeningHoursIntegrationTests: XCTestCase {
-    
+
     func testCanteensWithOpeningHours() async throws {
-        print("\n=== Canteen Opening Hours Integration Test ===\n")
-        
         let canteens = try await Canteen.all()
-        
         let canteensWithHours = canteens.filter { $0.openingHours != nil }
-        
-        print("Total canteens: \(canteens.count)")
-        print("Canteens with opening hours: \(canteensWithHours.count)\n")
-        
-        for canteen in canteensWithHours.sorted(by: { $0.name < $1.name }) {
-            print("\n📍 \(canteen.name) (ID: \(canteen.id))")
-            guard let hours = canteen.openingHours else { continue }
-            
-            if !hours.regularHours.isEmpty {
-                print("   Regular Hours:")
-                for slot in hours.regularHours.prefix(3) {
-                    print("      • \(slot.area): \(slot.hoursText)")
-                }
-                if hours.regularHours.count > 3 {
-                    print("      ... (\(hours.regularHours.count - 3) more)")
-                }
-            }
-            
-            if !hours.changedHours.isEmpty {
-                print("   Changed Hours: \(hours.changedHours.count) entries")
-            }
-        }
-        
-        print("\n✅ Matched \(canteensWithHours.count) out of \(canteens.count) canteens")
-        
-        // Assert we matched most canteens
+
         XCTAssertGreaterThanOrEqual(canteensWithHours.count, 10, "Should match at least 10 canteens with opening hours")
+
+        let names = canteensWithHours.sorted(by: { $0.name < $1.name }).map { "\($0.id) \($0.name)" }.joined(separator: ", ")
+        print("Matched \(canteensWithHours.count)/\(canteens.count) canteens: \(names)")
     }
 }

--- a/Tests/EmealKitTests/CanteenOpeningHoursIntegrationTests.swift
+++ b/Tests/EmealKitTests/CanteenOpeningHoursIntegrationTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import EmealKit
+
+/// Integration test to verify opening hours are matched to canteens
+final class CanteenOpeningHoursIntegrationTests: XCTestCase {
+    
+    func testCanteensWithOpeningHours() async throws {
+        print("\n=== Canteen Opening Hours Integration Test ===\n")
+        
+        let canteens = try await Canteen.all()
+        
+        let canteensWithHours = canteens.filter { $0.openingHours != nil }
+        
+        print("Total canteens: \(canteens.count)")
+        print("Canteens with opening hours: \(canteensWithHours.count)\n")
+        
+        for canteen in canteensWithHours.sorted(by: { $0.name < $1.name }) {
+            print("\n📍 \(canteen.name) (ID: \(canteen.id))")
+            guard let hours = canteen.openingHours else { continue }
+            
+            if !hours.regularHours.isEmpty {
+                print("   Regular Hours:")
+                for slot in hours.regularHours.prefix(3) {
+                    print("      • \(slot.area): \(slot.hoursText)")
+                }
+                if hours.regularHours.count > 3 {
+                    print("      ... (\(hours.regularHours.count - 3) more)")
+                }
+            }
+            
+            if !hours.changedHours.isEmpty {
+                print("   Changed Hours: \(hours.changedHours.count) entries")
+            }
+        }
+        
+        print("\n✅ Matched \(canteensWithHours.count) out of \(canteens.count) canteens")
+        
+        // Assert we matched most canteens
+        XCTAssertGreaterThanOrEqual(canteensWithHours.count, 10, "Should match at least 10 canteens with opening hours")
+    }
+}

--- a/Tests/EmealKitTests/OpeningHoursComplexTests.swift
+++ b/Tests/EmealKitTests/OpeningHoursComplexTests.swift
@@ -78,66 +78,50 @@ final class OpeningHoursComplexTests: XCTestCase {
     
     func testScenarioAt0900() {
         // At 09:00:
-        // Slot 1 (08-16) is OPEN
-        // Slot 2 (10-13) is CLOSED
-        // Slot 3 (10-13) is CLOSED and the only relevant one (changedHours)
-        // Next event: Slot 3 opens at 10:00
-        
+        // Changed hours (Slot 3, 11-13) override regular hours
+        // Slot 3 is closed → canteen is closed
+        // Next opening: Slot 3 at 11:00
+
         let now = monday(hour: 9)
-        
+
+        XCTAssertFalse(complexHours.isOpen(at: now))
+
         let openingTime = complexHours.openingTime(from: now)
-        XCTAssertNotNil(openingTime)
-        
-        // Should be 10:00
+        XCTAssertNotNil(openingTime.0)
+
         let components = calendar.dateComponents([.hour, .minute], from: openingTime.0!)
-        XCTAssertEqual(components.hour, 10)
+        XCTAssertEqual(components.hour, 11)
         XCTAssertEqual(components.minute, 0)
-        
-        // Tendency should be increasing (because 10:00 open is sooner than 16:00 close)
-        let open = complexHours.isOpen(at: now)
-        XCTAssertEqual(open, false)
     }
     
     func testScenarioAt1100() {
         // At 11:00:
-        // Slot 1 (08-16) is OPEN
-        // Slot 2 (10-13) is OPEN
-        // Slot 3 (10-13) is OPEN and the only relevant one (changedHours)
-        // Next event: Slot 3 closes at 13:00
-        
+        // Changed hours (Slot 3, 11-13) override regular hours
+        // Slot 3 is open → canteen is open, closes at 13:00
+
         let now = monday(hour: 11)
-        
-        // Closing time should be 13:00 (first thing to close)
+
+        XCTAssertTrue(complexHours.isOpen(at: now))
+
         let closingTime = complexHours.closingTime(from: now)
-        XCTAssertNotNil(closingTime)
-        
+        XCTAssertNotNil(closingTime.0)
+
         let components = calendar.dateComponents([.hour, .minute], from: closingTime.0!)
         XCTAssertEqual(components.hour, 13)
         XCTAssertEqual(components.minute, 0)
-        
-        // Tendency should be decreasing
-        let open = complexHours.isOpen(at: now)
-        XCTAssertEqual(open, true)
     }
     
     func testScenarioAt1400() {
         // At 14:00:
-        // Slot 1 (08-16) is OPEN
-        // Slot 2 (10-13) is CLOSED
-        // Slot 3 (10-13) is CLOSED and the only relevant one (changedHours)
-        // Next event: Slot 1 normally closes at 16:00 but the canteen is already closed
-        
+        // Changed hours (Slot 3, 11-13) override regular hours
+        // Slot 3 is closed → canteen is closed
+        // No closing time (nothing is open)
+
         let now = monday(hour: 14)
-        
+
+        XCTAssertFalse(complexHours.isOpen(at: now))
+
         let closingTime = complexHours.closingTime(from: now)
-        XCTAssertNotNil(closingTime)
-        
-        let components = calendar.dateComponents([.hour, .minute], from: closingTime.0!)
-        XCTAssertEqual(components.hour, 16)
-        XCTAssertEqual(components.minute, 0)
-        
-        // Tendency should be decreasing (next event is 16:00 close)
-        let open = complexHours.isOpen(at: now)
-        XCTAssertEqual(open, false)
+        XCTAssertNil(closingTime.0)
     }
 }

--- a/Tests/EmealKitTests/OpeningHoursComplexTests.swift
+++ b/Tests/EmealKitTests/OpeningHoursComplexTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import EmealKit
+
+final class OpeningHoursComplexTests: XCTestCase {
+    
+    // Scenario:
+    // Slot 1: 08:00 - 16:00
+    // Slot 2: 10:00 - 13:00
+    
+    var complexHours: OpeningHours!
+    var calendar: Calendar!
+    
+    override func setUp() {
+        super.setUp()
+        calendar = Calendar.current
+        calendar.timeZone = TimeZone(identifier: "Europe/Berlin")!
+        
+        let slot1 = OpeningHours.TimeSlot(
+            area: "Slot 1",
+            dateRange: nil,
+            hoursText: "08:00-16:00",
+            isRegular: true,
+            parsedHours: [
+                OpeningHours.WeekdayHours(
+                    days: [.monday],
+                    openTime: OpeningHours.TimeOfDay(hour: 8, minute: 0),
+                    closeTime: OpeningHours.TimeOfDay(hour: 16, minute: 0)
+                )
+            ]
+        )
+        
+        let slot2 = OpeningHours.TimeSlot(
+            area: "Slot 2",
+            dateRange: nil,
+            hoursText: "10:00-13:00",
+            isRegular: true,
+            parsedHours: [
+                OpeningHours.WeekdayHours(
+                    days: [.monday],
+                    openTime: OpeningHours.TimeOfDay(hour: 10, minute: 0),
+                    closeTime: OpeningHours.TimeOfDay(hour: 13, minute: 0)
+                )
+            ]
+        )
+        
+        let slot3 = OpeningHours.TimeSlot(
+            area: "Slot 3",
+            dateRange: nil,
+            hoursText: "11:00-13:00",
+            isRegular: false,
+            parsedHours: [
+                OpeningHours.WeekdayHours(
+                    days: [.monday],
+                    openTime: OpeningHours.TimeOfDay(hour: 11, minute: 0),
+                    closeTime: OpeningHours.TimeOfDay(hour: 13, minute: 0)
+                )
+            ]
+        )
+        
+        complexHours = OpeningHours(
+            canteenName: "Test Canteen",
+            regularHours: [slot1, slot2],
+            changedHours: [slot3]
+        )
+    }
+    
+    // Helper to create date for Monday at specific hour
+    func monday(hour: Int, minute: Int = 0) -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 26  // A Monday
+        components.hour = hour
+        components.minute = minute
+        components.timeZone = TimeZone(identifier: "Europe/Berlin")
+        return calendar.date(from: components)!
+    }
+    
+    func testScenarioAt0900() {
+        // At 09:00:
+        // Slot 1 (08-16) is OPEN
+        // Slot 2 (10-13) is CLOSED
+        // Slot 3 (10-13) is CLOSED and the only relevant one (changedHours)
+        // Next event: Slot 3 opens at 10:00
+        
+        let now = monday(hour: 9)
+        
+        let openingTime = complexHours.openingTime(from: now)
+        XCTAssertNotNil(openingTime)
+        
+        // Should be 10:00
+        let components = calendar.dateComponents([.hour, .minute], from: openingTime.0!)
+        XCTAssertEqual(components.hour, 10)
+        XCTAssertEqual(components.minute, 0)
+        
+        // Tendency should be increasing (because 10:00 open is sooner than 16:00 close)
+        let open = complexHours.isOpen(at: now)
+        XCTAssertEqual(open, false)
+    }
+    
+    func testScenarioAt1100() {
+        // At 11:00:
+        // Slot 1 (08-16) is OPEN
+        // Slot 2 (10-13) is OPEN
+        // Slot 3 (10-13) is OPEN and the only relevant one (changedHours)
+        // Next event: Slot 3 closes at 13:00
+        
+        let now = monday(hour: 11)
+        
+        // Closing time should be 13:00 (first thing to close)
+        let closingTime = complexHours.closingTime(from: now)
+        XCTAssertNotNil(closingTime)
+        
+        let components = calendar.dateComponents([.hour, .minute], from: closingTime.0!)
+        XCTAssertEqual(components.hour, 13)
+        XCTAssertEqual(components.minute, 0)
+        
+        // Tendency should be decreasing
+        let open = complexHours.isOpen(at: now)
+        XCTAssertEqual(open, true)
+    }
+    
+    func testScenarioAt1400() {
+        // At 14:00:
+        // Slot 1 (08-16) is OPEN
+        // Slot 2 (10-13) is CLOSED
+        // Slot 3 (10-13) is CLOSED and the only relevant one (changedHours)
+        // Next event: Slot 1 normally closes at 16:00 but the canteen is already closed
+        
+        let now = monday(hour: 14)
+        
+        let closingTime = complexHours.closingTime(from: now)
+        XCTAssertNotNil(closingTime)
+        
+        let components = calendar.dateComponents([.hour, .minute], from: closingTime.0!)
+        XCTAssertEqual(components.hour, 16)
+        XCTAssertEqual(components.minute, 0)
+        
+        // Tendency should be decreasing (next event is 16:00 close)
+        let open = complexHours.isOpen(at: now)
+        XCTAssertEqual(open, false)
+    }
+}

--- a/Tests/EmealKitTests/OpeningHoursDateTests.swift
+++ b/Tests/EmealKitTests/OpeningHoursDateTests.swift
@@ -145,6 +145,21 @@ final class OpeningHoursDateTests: XCTestCase {
         
         XCTAssertEqual(weekday, .tuesday)
     }
+
+    func testIsOpenUsesBerlinTimezone() {
+        let hours = OpeningHours.WeekdayHours(
+            days: [.monday, .tuesday, .wednesday, .thursday, .friday],
+            openTime: OpeningHours.TimeOfDay(hour: 11, minute: 0),
+            closeTime: OpeningHours.TimeOfDay(hour: 14, minute: 0)
+        )
+
+        // 10:30 UTC is 11:30 in Berlin (CET) on this date.
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        let date = formatter.date(from: "2026-01-26T10:30:00Z")!
+
+        XCTAssertTrue(hours.isOpen(at: date))
+    }
     
     func testTimeOfDayFromDate() {
         let calendar = Calendar.current

--- a/Tests/EmealKitTests/OpeningHoursDateTests.swift
+++ b/Tests/EmealKitTests/OpeningHoursDateTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import EmealKit
+
+final class OpeningHoursDateTests: XCTestCase {
+    
+    func testIsOpenWithDate() {
+        // Create opening hours: Mo-Fr 11:00-14:00
+        let hours = OpeningHours.WeekdayHours(
+            days: [.monday, .tuesday, .wednesday, .thursday, .friday],
+            openTime: OpeningHours.TimeOfDay(hour: 11, minute: 0),
+            closeTime: OpeningHours.TimeOfDay(hour: 14, minute: 0)
+        )
+        
+        // Create a date: Monday at 12:00
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 27  // Tuesday
+        components.hour = 12
+        components.minute = 0
+        components.timeZone = TimeZone(identifier: "Europe/Berlin")
+        
+        let calendar = Calendar.current
+        let testDate = calendar.date(from: components)!
+        
+        // Should be open
+        XCTAssertTrue(hours.isOpen(at: testDate))
+        
+        // Test before opening (10:00)
+        components.hour = 10
+        let beforeDate = calendar.date(from: components)!
+        XCTAssertFalse(hours.isOpen(at: beforeDate))
+        
+        // Test after closing (15:00)
+        components.hour = 15
+        let afterDate = calendar.date(from: components)!
+        XCTAssertFalse(hours.isOpen(at: afterDate))
+        
+        // Test on Saturday (closed)
+        components.day = 1  // Saturday, Feb 1
+        components.month = 2
+        components.hour = 12
+        let saturdayDate = calendar.date(from: components)!
+        XCTAssertFalse(hours.isOpen(at: saturdayDate))
+    }
+    
+    func testClosingTime() {
+        let hours = OpeningHours.WeekdayHours(
+            days: [.monday, .tuesday, .wednesday, .thursday, .friday],
+            openTime: OpeningHours.TimeOfDay(hour: 11, minute: 0),
+            closeTime: OpeningHours.TimeOfDay(hour: 14, minute: 30)
+        )
+        
+        // Test during opening hours
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 27  // Tuesday
+        components.hour = 12
+        components.minute = 0
+        components.timeZone = TimeZone(identifier: "Europe/Berlin")
+        
+        let calendar = Calendar.current
+        let testDate = calendar.date(from: components)!
+        
+        let closingTime = hours.closingTime(from: testDate)
+        XCTAssertNotNil(closingTime)
+        
+        // Should be 14:30 same day
+        let closingComponents = calendar.dateComponents([.hour, .minute], from: closingTime!)
+        XCTAssertEqual(closingComponents.hour, 14)
+        XCTAssertEqual(closingComponents.minute, 30)
+    }
+    
+    func testOpeningTime() {
+        let hours = OpeningHours.WeekdayHours(
+            days: [.monday, .tuesday, .wednesday, .thursday, .friday],
+            openTime: OpeningHours.TimeOfDay(hour: 11, minute: 0),
+            closeTime: OpeningHours.TimeOfDay(hour: 14, minute: 0)
+        )
+        
+        // Test before opening hours (10:00 Tuesday)
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 27  // Tuesday
+        components.hour = 10
+        components.minute = 0
+        components.timeZone = TimeZone(identifier: "Europe/Berlin")
+        
+        let calendar = Calendar.current
+        let testDate = calendar.date(from: components)!
+        
+        let openingTime = hours.openingTime(from: testDate)
+        XCTAssertNotNil(openingTime)
+        
+        // Should be 11:00 same day
+        let openingComponents = calendar.dateComponents([.hour, .minute, .day], from: openingTime!)
+        XCTAssertEqual(openingComponents.hour, 11)
+        XCTAssertEqual(openingComponents.minute, 0)
+        XCTAssertEqual(openingComponents.day, 27)
+    }
+    
+    func testOpeningTimeNextDay() {
+        let hours = OpeningHours.WeekdayHours(
+            days: [.monday, .tuesday, .wednesday, .thursday, .friday],
+            openTime: OpeningHours.TimeOfDay(hour: 11, minute: 0),
+            closeTime: OpeningHours.TimeOfDay(hour: 14, minute: 0)
+        )
+        
+        // Test on Saturday afternoon (closed)
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 31  // Saturday
+        components.hour = 15
+        components.minute = 0
+        components.timeZone = TimeZone(identifier: "Europe/Berlin")
+        
+        let calendar = Calendar.current
+        let testDate = calendar.date(from: components)!
+        
+        let openingTime = hours.openingTime(from: testDate)
+        XCTAssertNotNil(openingTime)
+        
+        // Should be Monday 11:00
+        let openingComponents = calendar.dateComponents([.weekday, .hour, .minute], from: openingTime!)
+        XCTAssertEqual(openingComponents.weekday, 2)  // Monday
+        XCTAssertEqual(openingComponents.hour, 11)
+        XCTAssertEqual(openingComponents.minute, 0)
+    }
+    
+    func testWeekdayFromDate() {
+        let calendar = Calendar.current
+        
+        // Tuesday, January 27, 2026
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 27
+        components.timeZone = TimeZone(identifier: "Europe/Berlin")
+        
+        let testDate = calendar.date(from: components)!
+        let weekday = OpeningHours.Weekday.from(date: testDate, calendar: calendar)
+        
+        XCTAssertEqual(weekday, .tuesday)
+    }
+    
+    func testTimeOfDayFromDate() {
+        let calendar = Calendar.current
+        
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 1
+        components.day = 27
+        components.hour = 14
+        components.minute = 35
+        components.timeZone = TimeZone(identifier: "Europe/Berlin")
+        
+        let testDate = calendar.date(from: components)!
+        let timeOfDay = OpeningHours.TimeOfDay.from(date: testDate, calendar: calendar)
+        
+        XCTAssertEqual(timeOfDay.hour, 14)
+        XCTAssertEqual(timeOfDay.minute, 35)
+    }
+}

--- a/Tests/EmealKitTests/OpeningHoursIntegrationTests.swift
+++ b/Tests/EmealKitTests/OpeningHoursIntegrationTests.swift
@@ -1,129 +1,19 @@
 import XCTest
 @testable import EmealKit
 
-/// Integration test for opening hours scraping - compares with actual website
-/// Run this manually to validate against https://www.studentenwerk-dresden.de/mensen/oeffnungszeiten.html
+/// Integration test for opening hours scraping
+/// Validates against https://www.studentenwerk-dresden.de/mensen/oeffnungszeiten.html
 final class OpeningHoursIntegrationTests: XCTestCase {
-    
+
     func testFetchAndParseRealOpeningHours() async throws {
-        print("\n=== Opening Hours Integration Test ===\n")
-        print("Fetching from: https://www.studentenwerk-dresden.de/mensen/oeffnungszeiten.html\n")
-        
         let openingHoursList = try await OpeningHoursScraper.fetchOpeningHours()
-        
-        print("Found opening hours for \(openingHoursList.count) canteens\n")
-        
-        // Sort by canteen name for easier comparison
-        let sortedCanteens = openingHoursList.sorted { $0.canteenName < $1.canteenName }
-        
-        for canteen in sortedCanteens {
-            print("\n📍 \(canteen.canteenName)")
-            
-            // Show regular hours
-            if !canteen.regularHours.isEmpty {
-                print("\n   Regular Hours:")
-                for timeSlot in canteen.regularHours {
-                    print("      \(timeSlot.area):")
-                    
-                    if !timeSlot.parsedHours.isEmpty {
-                        for schedule in timeSlot.parsedHours {
-                            let daysStr = formatDays(schedule.days)
-                            let timeStr = "\(schedule.openTime.formatted) - \(schedule.closeTime.formatted)"
-                            
-                            if let label = schedule.label {
-                                print("         \(daysStr): \(timeStr) (\(label))")
-                            } else {
-                                print("         \(daysStr): \(timeStr)")
-                            }
-                        }
-                    } else {
-                        print("         \(timeSlot.hoursText)")
-                    }
-                }
-            }
-            
-            // Show changed hours
-            if !canteen.changedHours.isEmpty {
-                print("\n   Changed Hours:")
-                for timeSlot in canteen.changedHours {
-                    print("      \(timeSlot.area):")
-                    
-                    if let dateRange = timeSlot.dateRange {
-                        print("         📅 \(dateRange.text) [\(dateRange.from?.dayMonthYear) -> \(dateRange.to?.dayMonthYear)]")
-                    }
-                    
-                    if !timeSlot.parsedHours.isEmpty {
-                        for schedule in timeSlot.parsedHours {
-                            let daysStr = formatDays(schedule.days)
-                            let timeStr = "\(schedule.openTime.formatted) - \(schedule.closeTime.formatted)"
-                            
-                            if let label = schedule.label {
-                                print("         \(daysStr): \(timeStr) (\(label))")
-                            } else {
-                                print("         \(daysStr): \(timeStr)")
-                            }
-                        }
-                    } else {
-                        print("         \(timeSlot.hoursText)")
-                    }
-                }
-            }
-            
-            if canteen.regularHours.isEmpty && canteen.changedHours.isEmpty {
-                print("   No opening hours data")
-            }
-        }
-        
-        print("\n✅ Compare the output above with the website!")
-        print("   URL: https://www.studentenwerk-dresden.de/mensen/oeffnungszeiten.html\n")
-    }
-    
-    // MARK: - Helpers
-    
-    private func formatDays(_ days: Set<OpeningHours.Weekday>) -> String {
-        let sorted = days.sorted { $0.rawValue < $1.rawValue }
-        
-        // Try to detect ranges
-        if let range = detectRange(sorted) {
-            return range
-        }
-        
-        // Otherwise, comma-separated
-        return sorted.map { $0.rawValue }.joined(separator: ", ")
-    }
-    
-    private func detectRange(_ days: [OpeningHours.Weekday]) -> String? {
-        guard days.count >= 2 else {
-            return days.first?.rawValue
-        }
-        
-        let allDays = OpeningHours.Weekday.allCases
-        
-        // Check if consecutive
-        var indices: [Int] = []
-        for day in days {
-            if let idx = allDays.firstIndex(of: day) {
-                indices.append(idx)
-            }
-        }
-        
-        indices.sort()
-        
-        // Check if consecutive
-        var isConsecutive = true
-        for i in 1..<indices.count {
-            if indices[i] != indices[i-1] + 1 {
-                isConsecutive = false
-                break
-            }
-        }
-        
-        if isConsecutive {
-            let first = allDays[indices.first!]
-            let last = allDays[indices.last!]
-            return "\(first.rawValue) - \(last.rawValue)"
-        }
-        
-        return nil
+
+        XCTAssertFalse(openingHoursList.isEmpty, "Should find at least one canteen")
+
+        let withRegular = openingHoursList.filter { !$0.regularHours.isEmpty }.count
+        let withChanged = openingHoursList.filter { !$0.changedHours.isEmpty }.count
+        let names = openingHoursList.map(\.canteenName).sorted().joined(separator: ", ")
+
+        print("Parsed \(openingHoursList.count) canteens (\(withRegular) with regular hours, \(withChanged) with changed hours): \(names)")
     }
 }

--- a/Tests/EmealKitTests/OpeningHoursIntegrationTests.swift
+++ b/Tests/EmealKitTests/OpeningHoursIntegrationTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import EmealKit
+
+/// Integration test for opening hours scraping - compares with actual website
+/// Run this manually to validate against https://www.studentenwerk-dresden.de/mensen/oeffnungszeiten.html
+final class OpeningHoursIntegrationTests: XCTestCase {
+    
+    func testFetchAndParseRealOpeningHours() async throws {
+        print("\n=== Opening Hours Integration Test ===\n")
+        print("Fetching from: https://www.studentenwerk-dresden.de/mensen/oeffnungszeiten.html\n")
+        
+        let openingHoursList = try await OpeningHoursScraper.fetchOpeningHours()
+        
+        print("Found opening hours for \(openingHoursList.count) canteens\n")
+        
+        // Sort by canteen name for easier comparison
+        let sortedCanteens = openingHoursList.sorted { $0.canteenName < $1.canteenName }
+        
+        for canteen in sortedCanteens {
+            print("\n📍 \(canteen.canteenName)")
+            
+            // Show regular hours
+            if !canteen.regularHours.isEmpty {
+                print("\n   Regular Hours:")
+                for timeSlot in canteen.regularHours {
+                    print("      \(timeSlot.area):")
+                    
+                    if !timeSlot.parsedHours.isEmpty {
+                        for schedule in timeSlot.parsedHours {
+                            let daysStr = formatDays(schedule.days)
+                            let timeStr = "\(schedule.openTime.formatted) - \(schedule.closeTime.formatted)"
+                            
+                            if let label = schedule.label {
+                                print("         \(daysStr): \(timeStr) (\(label))")
+                            } else {
+                                print("         \(daysStr): \(timeStr)")
+                            }
+                        }
+                    } else {
+                        print("         \(timeSlot.hoursText)")
+                    }
+                }
+            }
+            
+            // Show changed hours
+            if !canteen.changedHours.isEmpty {
+                print("\n   Changed Hours:")
+                for timeSlot in canteen.changedHours {
+                    print("      \(timeSlot.area):")
+                    
+                    if let dateRange = timeSlot.dateRange {
+                        print("         📅 \(dateRange.text) [\(dateRange.from?.dayMonthYear) -> \(dateRange.to?.dayMonthYear)]")
+                    }
+                    
+                    if !timeSlot.parsedHours.isEmpty {
+                        for schedule in timeSlot.parsedHours {
+                            let daysStr = formatDays(schedule.days)
+                            let timeStr = "\(schedule.openTime.formatted) - \(schedule.closeTime.formatted)"
+                            
+                            if let label = schedule.label {
+                                print("         \(daysStr): \(timeStr) (\(label))")
+                            } else {
+                                print("         \(daysStr): \(timeStr)")
+                            }
+                        }
+                    } else {
+                        print("         \(timeSlot.hoursText)")
+                    }
+                }
+            }
+            
+            if canteen.regularHours.isEmpty && canteen.changedHours.isEmpty {
+                print("   No opening hours data")
+            }
+        }
+        
+        print("\n✅ Compare the output above with the website!")
+        print("   URL: https://www.studentenwerk-dresden.de/mensen/oeffnungszeiten.html\n")
+    }
+    
+    // MARK: - Helpers
+    
+    private func formatDays(_ days: Set<OpeningHours.Weekday>) -> String {
+        let sorted = days.sorted { $0.rawValue < $1.rawValue }
+        
+        // Try to detect ranges
+        if let range = detectRange(sorted) {
+            return range
+        }
+        
+        // Otherwise, comma-separated
+        return sorted.map { $0.rawValue }.joined(separator: ", ")
+    }
+    
+    private func detectRange(_ days: [OpeningHours.Weekday]) -> String? {
+        guard days.count >= 2 else {
+            return days.first?.rawValue
+        }
+        
+        let allDays = OpeningHours.Weekday.allCases
+        
+        // Check if consecutive
+        var indices: [Int] = []
+        for day in days {
+            if let idx = allDays.firstIndex(of: day) {
+                indices.append(idx)
+            }
+        }
+        
+        indices.sort()
+        
+        // Check if consecutive
+        var isConsecutive = true
+        for i in 1..<indices.count {
+            if indices[i] != indices[i-1] + 1 {
+                isConsecutive = false
+                break
+            }
+        }
+        
+        if isConsecutive {
+            let first = allDays[indices.first!]
+            let last = allDays[indices.last!]
+            return "\(first.rawValue) - \(last.rawValue)"
+        }
+        
+        return nil
+    }
+}

--- a/Tests/EmealKitTests/OpeningHoursParserTests.swift
+++ b/Tests/EmealKitTests/OpeningHoursParserTests.swift
@@ -250,6 +250,21 @@ final class OpeningHoursParserTests: XCTestCase {
         )
         XCTAssertFalse(futureRange.isActive(on: today))
     }
+
+    func testDateRangeEndDateIsInclusiveByDay() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Europe/Berlin")!
+
+        let from = calendar.date(from: DateComponents(year: 2026, month: 2, day: 9, hour: 0, minute: 0))!
+        let to = calendar.date(from: DateComponents(year: 2026, month: 2, day: 20, hour: 0, minute: 0))!
+        let range = OpeningHours.DateRange(from: from, to: to, text: "09.02.26 - 20.02.26")
+
+        let onEndDayNoon = calendar.date(from: DateComponents(year: 2026, month: 2, day: 20, hour: 12, minute: 0))!
+        let dayAfter = calendar.date(from: DateComponents(year: 2026, month: 2, day: 21, hour: 0, minute: 1))!
+
+        XCTAssertTrue(range.isActive(on: onEndDayNoon))
+        XCTAssertFalse(range.isActive(on: dayAfter))
+    }
     
     // MARK: - TimeOfDay Tests
     

--- a/Tests/EmealKitTests/OpeningHoursParserTests.swift
+++ b/Tests/EmealKitTests/OpeningHoursParserTests.swift
@@ -1,0 +1,338 @@
+import XCTest
+@testable import EmealKit
+
+final class OpeningHoursParserTests: XCTestCase {
+    
+    // MARK: - Weekday Parsing Tests
+    
+    func testParseWeekdayRange() throws {
+        // Test "Mo-Fr"
+        let days1 = OpeningHoursParser.parseWeekdays("Mo-Fr")
+        XCTAssertEqual(days1.count, 5)
+        XCTAssertTrue(days1.contains(.monday))
+        XCTAssertTrue(days1.contains(.friday))
+        XCTAssertFalse(days1.contains(.saturday))
+        
+        // Test "Mo - Do" (with spaces)
+        let days2 = OpeningHoursParser.parseWeekdays("Mo - Do")
+        XCTAssertEqual(days2.count, 4)
+        XCTAssertTrue(days2.contains(.monday))
+        XCTAssertTrue(days2.contains(.thursday))
+        XCTAssertFalse(days2.contains(.friday))
+        
+        // Test "Montag - Freitag" (full German names)
+        let days3 = OpeningHoursParser.parseWeekdays("Montag - Freitag")
+        XCTAssertEqual(days3.count, 5)
+        XCTAssertTrue(days3.contains(.monday))
+        XCTAssertTrue(days3.contains(.friday))
+    }
+    
+    func testParseSingleWeekday() throws {
+        let days1 = OpeningHoursParser.parseWeekdays("Mo")
+        XCTAssertEqual(days1, [.monday])
+        
+        let days2 = OpeningHoursParser.parseWeekdays("Freitag")
+        XCTAssertEqual(days2, [.friday])
+    }
+    
+    func testParseCommaSeparatedWeekdays() throws {
+        let days = OpeningHoursParser.parseWeekdays("Mo, Mi, Fr")
+        XCTAssertEqual(days.count, 3)
+        XCTAssertTrue(days.contains(.monday))
+        XCTAssertTrue(days.contains(.wednesday))
+        XCTAssertTrue(days.contains(.friday))
+        XCTAssertFalse(days.contains(.tuesday))
+    }
+    
+    // MARK: - Time Parsing Tests
+    
+    func testParseTime() throws {
+        // Test "11:00"
+        let time1 = OpeningHoursParser.parseTime("11:00")
+        XCTAssertEqual(time1?.hour, 11)
+        XCTAssertEqual(time1?.minute, 0)
+        
+        // Test "11:00 Uhr"
+        let time2 = OpeningHoursParser.parseTime("11:00 Uhr")
+        XCTAssertEqual(time2?.hour, 11)
+        XCTAssertEqual(time2?.minute, 0)
+        
+        // Test "8:00"
+        let time3 = OpeningHoursParser.parseTime("8:00")
+        XCTAssertEqual(time3?.hour, 8)
+        XCTAssertEqual(time3?.minute, 0)
+        
+        // Test "14:30"
+        let time4 = OpeningHoursParser.parseTime("14:30")
+        XCTAssertEqual(time4?.hour, 14)
+        XCTAssertEqual(time4?.minute, 30)
+    }
+    
+    func testParseTimeRange() throws {
+        // Test "11:00 - 14:00"
+        let range1 = OpeningHoursParser.parseTimeRange("11:00 - 14:00")
+        XCTAssertEqual(range1?.0.hour, 11)
+        XCTAssertEqual(range1?.1.hour, 14)
+        
+        // Test "von 8:00 bis 17:00 Uhr"
+        let range2 = OpeningHoursParser.parseTimeRange("von 8:00 bis 17:00 Uhr")
+        XCTAssertEqual(range2?.0.hour, 8)
+        XCTAssertEqual(range2?.1.hour, 17)
+        
+        // Test "10:45-14:45" (no spaces)
+        let range3 = OpeningHoursParser.parseTimeRange("10:45-14:45")
+        XCTAssertEqual(range3?.0.hour, 10)
+        XCTAssertEqual(range3?.0.minute, 45)
+        XCTAssertEqual(range3?.1.hour, 14)
+        XCTAssertEqual(range3?.1.minute, 45)
+    }
+    
+    // MARK: - Complete Hours Text Parsing Tests
+    
+    func testParseSimpleHours() throws {
+        // Test "Mo - Fr 11:00 - 14:00 Uhr"
+        let hours1 = OpeningHoursParser.parseHoursText("Mo - Fr 11:00 - 14:00 Uhr", label: "Mittagstisch")
+        XCTAssertEqual(hours1.count, 1)
+        XCTAssertEqual(hours1[0].label, "Mittagstisch")
+        XCTAssertEqual(hours1[0].days.count, 5)
+        XCTAssertTrue(hours1[0].days.contains(.monday))
+        XCTAssertTrue(hours1[0].days.contains(.friday))
+        XCTAssertEqual(hours1[0].openTime.hour, 11)
+        XCTAssertEqual(hours1[0].closeTime.hour, 14)
+        
+        // Test "Montag - Freitag 08:00 - 15:00 Uhr"
+        let hours2 = OpeningHoursParser.parseHoursText("Montag - Freitag 08:00 - 15:00 Uhr")
+        XCTAssertEqual(hours2.count, 1)
+        XCTAssertEqual(hours2[0].days.count, 5)
+        XCTAssertEqual(hours2[0].openTime.hour, 8)
+    }
+    
+    func testParseComplexHours() throws {
+        // Test "Mo - Do von 10:45-14:45 Uhr und Fr von 10:45-14:15 Uhr"
+        let hours = OpeningHoursParser.parseHoursText(
+            "Mo - Do von 10:45-14:45 Uhr und Fr von 10:45-14:15 Uhr",
+            label: "Mittagstisch im Brat²"
+        )
+        
+        XCTAssertEqual(hours.count, 2)
+        
+        // First segment: Mo - Do
+        XCTAssertEqual(hours[0].label, "Mittagstisch im Brat²")
+        XCTAssertEqual(hours[0].days.count, 4)
+        XCTAssertTrue(hours[0].days.contains(.monday))
+        XCTAssertTrue(hours[0].days.contains(.thursday))
+        XCTAssertFalse(hours[0].days.contains(.friday))
+        XCTAssertEqual(hours[0].openTime.hour, 10)
+        XCTAssertEqual(hours[0].openTime.minute, 45)
+        XCTAssertEqual(hours[0].closeTime.hour, 14)
+        XCTAssertEqual(hours[0].closeTime.minute, 45)
+        
+        // Second segment: Fr
+        XCTAssertEqual(hours[1].label, "Mittagstisch im Brat²")
+        XCTAssertEqual(hours[1].days, [.friday])
+        XCTAssertEqual(hours[1].openTime.hour, 10)
+        XCTAssertEqual(hours[1].openTime.minute, 45)
+        XCTAssertEqual(hours[1].closeTime.hour, 14)
+        XCTAssertEqual(hours[1].closeTime.minute, 15)
+    }
+    
+    func testParseSplitHoursSameDay() throws {
+        // Test "Montag - Donnerstag 09:00 - 15:00 Uhr und 15:30 - 18:30 Uhr"
+        let hours = OpeningHoursParser.parseHoursText(
+            "Montag - Donnerstag 09:00 - 15:00 Uhr und 15:30 - 18:30 Uhr"
+        )
+        
+        XCTAssertEqual(hours.count, 2, "Should parse two time ranges")
+        
+        // First time range: 09:00 - 15:00
+        XCTAssertEqual(hours[0].days.count, 4)
+        XCTAssertTrue(hours[0].days.contains(.monday))
+        XCTAssertTrue(hours[0].days.contains(.thursday))
+        XCTAssertEqual(hours[0].openTime.hour, 9)
+        XCTAssertEqual(hours[0].closeTime.hour, 15)
+        
+        // Second time range: 15:30 - 18:30 (same days)
+        XCTAssertEqual(hours[1].days.count, 4)
+        XCTAssertTrue(hours[1].days.contains(.monday))
+        XCTAssertTrue(hours[1].days.contains(.thursday))
+        XCTAssertEqual(hours[1].openTime.hour, 15)
+        XCTAssertEqual(hours[1].openTime.minute, 30)
+        XCTAssertEqual(hours[1].closeTime.hour, 18)
+        XCTAssertEqual(hours[1].closeTime.minute, 30)
+    }
+    
+    func testParseClosedHours() throws {
+        let hours1 = OpeningHoursParser.parseHoursText("geschlossen")
+        XCTAssertEqual(hours1.count, 0)
+        
+        let hours2 = OpeningHoursParser.parseHoursText("Die Mensa ist geschlossen.")
+        XCTAssertEqual(hours2.count, 0)
+    }
+    
+    // MARK: - Date Range Parsing Tests
+    
+    func testParseDateRange() throws {
+        // Test "09.02.26 - 20.02.26"
+        let range1 = OpeningHoursParser.parseDateRange("09.02.26 - 20.02.26")
+        XCTAssertNotNil(range1)
+        XCTAssertEqual(range1?.text, "09.02.26 - 20.02.26")
+        XCTAssertNotNil(range1?.from)
+        XCTAssertNotNil(range1?.to)
+        
+        let calendar = Calendar.current
+        if let from = range1?.from {
+            XCTAssertEqual(calendar.component(.day, from: from), 9)
+            XCTAssertEqual(calendar.component(.month, from: from), 2)
+            XCTAssertEqual(calendar.component(.year, from: from), 2026)
+        }
+        
+        if let to = range1?.to {
+            XCTAssertEqual(calendar.component(.day, from: to), 20)
+            XCTAssertEqual(calendar.component(.month, from: to), 2)
+            XCTAssertEqual(calendar.component(.year, from: to), 2026)
+        }
+        
+        let range2 = OpeningHoursParser.parseDateRange("06.01. - 05.01.2027")
+        XCTAssertNotNil(range2)
+        XCTAssertEqual(range2?.text, "06.01. - 05.01.2027")
+        XCTAssertNotNil(range2?.from)
+        XCTAssertNotNil(range2?.to)
+        
+        if let from = range2?.from {
+            XCTAssertEqual(calendar.component(.day, from: from), 6)
+            XCTAssertEqual(calendar.component(.month, from: from), 1)
+            XCTAssertEqual(calendar.component(.year, from: from), 2026)
+        }
+        
+        if let to = range2?.to {
+            XCTAssertEqual(calendar.component(.day, from: to), 5)
+            XCTAssertEqual(calendar.component(.month, from: to), 1)
+            XCTAssertEqual(calendar.component(.year, from: to), 2027)
+        }
+        
+        // Test "bis 03.02.26"
+        let range3 = OpeningHoursParser.parseDateRange("bis 03.02.26")
+        XCTAssertNotNil(range3)
+        XCTAssertNil(range3?.from)
+        XCTAssertNotNil(range3?.to)
+        
+        // Test "ab 06.06.25"
+        let range4 = OpeningHoursParser.parseDateRange("ab 06.06.25")
+        XCTAssertNotNil(range4)
+        XCTAssertNotNil(range4?.from)
+        XCTAssertNil(range4?.to)
+    }
+    
+    func testDateRangeIsActive() throws {
+        let calendar = Calendar.current
+        let today = Date()
+        
+        // Create a range that includes today
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: today)!
+        
+        let activeRange = OpeningHours.DateRange(from: yesterday, to: tomorrow, text: "test")
+        XCTAssertTrue(activeRange.isActive(on: today))
+        
+        // Create a range in the past
+        let pastRange = OpeningHours.DateRange(
+            from: calendar.date(byAdding: .day, value: -10, to: today),
+            to: calendar.date(byAdding: .day, value: -5, to: today),
+            text: "test"
+        )
+        XCTAssertFalse(pastRange.isActive(on: today))
+        
+        // Create a range in the future
+        let futureRange = OpeningHours.DateRange(
+            from: calendar.date(byAdding: .day, value: 5, to: today),
+            to: calendar.date(byAdding: .day, value: 10, to: today),
+            text: "test"
+        )
+        XCTAssertFalse(futureRange.isActive(on: today))
+    }
+    
+    // MARK: - TimeOfDay Tests
+    
+    func testTimeOfDayComparison() throws {
+        let morning = OpeningHours.TimeOfDay(hour: 8, minute: 0)
+        let noon = OpeningHours.TimeOfDay(hour: 12, minute: 0)
+        let afternoon = OpeningHours.TimeOfDay(hour: 14, minute: 30)
+        
+        XCTAssertTrue(morning < noon)
+        XCTAssertTrue(noon < afternoon)
+        XCTAssertTrue(morning < afternoon)
+        XCTAssertFalse(afternoon < morning)
+    }
+    
+    func testTimeOfDayFormatted() throws {
+        let time1 = OpeningHours.TimeOfDay(hour: 8, minute: 0)
+        XCTAssertEqual(time1.formatted, "08:00")
+        
+        let time2 = OpeningHours.TimeOfDay(hour: 14, minute: 45)
+        XCTAssertEqual(time2.formatted, "14:45")
+    }
+    
+    // MARK: - WeekdayHours isOpen Tests
+    
+    func testIsOpen() throws {
+        let hours = OpeningHours.WeekdayHours(
+            label: "Mittagstisch",
+            days: [.monday, .tuesday, .wednesday, .thursday, .friday],
+            openTime: OpeningHours.TimeOfDay(hour: 11, minute: 0),
+            closeTime: OpeningHours.TimeOfDay(hour: 14, minute: 0)
+        )
+        
+        // Test during opening hours
+        XCTAssertTrue(hours.isOpen(on: .monday, at: OpeningHours.TimeOfDay(hour: 12, minute: 0)))
+        XCTAssertTrue(hours.isOpen(on: .friday, at: OpeningHours.TimeOfDay(hour: 13, minute: 30)))
+        
+        // Test at exact opening time
+        XCTAssertTrue(hours.isOpen(on: .monday, at: OpeningHours.TimeOfDay(hour: 11, minute: 0)))
+        
+        // Test at exact closing time
+        XCTAssertTrue(hours.isOpen(on: .monday, at: OpeningHours.TimeOfDay(hour: 14, minute: 0)))
+        
+        // Test before opening
+        XCTAssertFalse(hours.isOpen(on: .monday, at: OpeningHours.TimeOfDay(hour: 10, minute: 0)))
+        
+        // Test after closing
+        XCTAssertFalse(hours.isOpen(on: .monday, at: OpeningHours.TimeOfDay(hour: 15, minute: 0)))
+        
+        // Test on closed day
+        XCTAssertFalse(hours.isOpen(on: .saturday, at: OpeningHours.TimeOfDay(hour: 12, minute: 0)))
+    }
+    
+    // MARK: - Real-World Example Tests
+    
+    func testRealWorldExamples() throws {
+        // Mensa Matrix
+        let matrix = OpeningHoursParser.parseHoursText(
+            "Mo - Fr 10:45 - 14:00 Uhr (Hausschließung 14:30 Uhr)"
+        )
+        XCTAssertEqual(matrix.count, 1)
+        XCTAssertEqual(matrix[0].days.count, 5)
+        
+        // Alte Mensa - Cafeteria Zebradiele
+        let zebradiele = OpeningHoursParser.parseHoursText(
+            "Mo - Fr von 8:00 bis 17:00 Uhr",
+            label: "Öffnungszeiten Cafeteria Zebradiele"
+        )
+        XCTAssertGreaterThanOrEqual(zebradiele.count, 1, "Should parse at least one time slot")
+        if zebradiele.count >= 1 {
+            XCTAssertEqual(zebradiele[0].label, "Öffnungszeiten Cafeteria Zebradiele")
+            XCTAssertEqual(zebradiele[0].openTime.hour, 8)
+            XCTAssertEqual(zebradiele[0].closeTime.hour, 17)
+        }
+        
+        // Mensa Siedepunkt - Abendangebot (multi-line)
+        let abend = OpeningHoursParser.parseHoursText(
+            "Montag - Freitag 17:30 Uhr - 20:00 Uhr\nEssenausgabe      17:30 Uhr - 19:45 Uhr"
+        )
+        // Should parse at least the first time range
+        XCTAssertGreaterThanOrEqual(abend.count, 1)
+        if abend.count >= 1 {
+            XCTAssertEqual(abend[0].openTime.hour, 17)
+            XCTAssertEqual(abend[0].openTime.minute, 30)
+        }
+    }
+}


### PR DESCRIPTION
This PR uses https://www.studentenwerk-dresden.de/mensen/oeffnungszeiten.html with some funny matching and regex logic to extract opening hours for the canteens (and possibly the dedicated cafe's in the future as well).

It adds `openingHours` along with `isOpen(at: Date)`, `closingTime` and `openingTime` utility methods to the `Canteen` struct.

I also implemented support for `changedHours` to make it possible to be informed about service disruptions.

Also fixes a few minor inconviniences that existed with cardservice for kiliankoe/MensaDresden#103 